### PR TITLE
fix: force CheckFailed msg arg to string

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -1,8 +1,12 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '0 8 * * TUE'
 
 jobs:
   lint:

--- a/src/charm.py
+++ b/src/charm.py
@@ -20,12 +20,12 @@ from serialized_data_interface import (
 class CheckFailed(Exception):
     """ Raise this exception if one of the checks in main fails. """
 
-    def __init__(self, msg, status_type=None):
+    def __init__(self, msg: str, status_type=None):
         super().__init__()
 
-        self.msg = msg
+        self.msg = str(msg)
         self.status_type = status_type
-        self.status = status_type(msg)
+        self.status = status_type(self.msg)
 
 
 class Operator(CharmBase):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -40,11 +40,12 @@ async def test_build_and_deploy(ops_test):
 @pytest.mark.abort_on_fail
 async def test_add_profile_relation(ops_test):
     charm_name = METADATA["name"]
-    await ops_test.model.deploy("cs:kubeflow-profiles")
+    # TODO: Point kubeflow-profiles to latest/stable when Rev 54 or higher are promoted
+    await ops_test.model.deploy("kubeflow-profiles", channel="latest/edge")
     await ops_test.model.add_relation("kubeflow-profiles", charm_name)
     await ops_test.model.wait_for_idle(
         ["kubeflow-profiles", charm_name],
-        wait_for_active=True,
+        status='active',
         raise_on_blocked=True,
         raise_on_error=True,
         timeout=300,

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -45,7 +45,7 @@ async def test_add_profile_relation(ops_test):
     await ops_test.model.add_relation("kubeflow-profiles", charm_name)
     await ops_test.model.wait_for_idle(
         ["kubeflow-profiles", charm_name],
-        status='active',
+        status="active",
         raise_on_blocked=True,
         raise_on_error=True,
         timeout=300,


### PR DESCRIPTION
fixes error where non-string input will cause an exception when instantiating the `status`