### PR TITLE
Remove Artifacts and Executions pages

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -37,18 +37,6 @@
         },
         {
             "type": "item",
-            "link": "/pipeline/#/artifacts",
-            "text": "Artifacts",
-            "icon": "editor:bubble-chart"
-        },
-        {
-            "type": "item",
-            "link": "/pipeline/#/executions",
-            "text": "Executions",
-            "icon": "av:play-arrow"
-        },
-        {
-            "type": "item",
             "link": "/volumes/",
             "text": "Volumes",
             "icon": "device:storage"

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -114,8 +114,11 @@ def test_links(driver):
         "/pipeline/#/pipelines",
         "/pipeline/#/runs",
         "/pipeline/#/recurringruns",
-        "/pipeline/#/artifacts",
-        "/pipeline/#/executions",
+        # Removed temporarily until https://warthogs.atlassian.net/browse/KF-175 is fixed
+        # "/pipeline/#/artifacts",
+        # "/pipeline/#/executions",
+        "/volumes/",
+        "/tensorboards/",
     ]
 
     for link in links:


### PR DESCRIPTION
We have not charmed the Artifacts and Executions features, so this change removes those dead links from the dashboard.  We can reinstate them when we've enabled the features.