### PR TITLE
Add min-juju-version element to prevent excess PVC creation

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -3,6 +3,7 @@
 name: kubeflow-dashboard
 summary: Kubeflow Central Dashboard
 description: Kubeflow Central Dashboard
+min-juju-version: "2.9.0"
 series: [kubernetes]
 resources:
   oci-image:


### PR DESCRIPTION
ThIs PR addresses GH-425 where a PVC is created per operator, adding the `min-juju-version: 2.9.0` element to prevent that PVC creation.