### PR TITLE
Support k8s v1.22+ with kubeflow 1.5

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -60,7 +60,7 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
             provider: microk8s
-            channel: 1.21/stable
+            channel: 1.22/stable
             charmcraft-channel: latest/candidate
 
       # TODO: Remove once the actions-operator does this automatically

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 __pycache__
 *.charm
 geckodriver.log
+.idea

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -13,4 +13,5 @@ parts:
   charm:
     prime:
       - files/*yaml
-    charm-python-packages: [setuptools, pip]  # Fixes install of some packages
+    # do not use these versions due to pypa/setuptools_scm#713
+    charm-python-packages: [ setuptools!=62.2.0, pip!=22.1 ]

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,7 +10,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: public.ecr.aws/j1r0q0g6/notebooks/central-dashboard:v1.4-rc.0
+    upstream-source: public.ecr.aws/j1r0q0g6/notebooks/central-dashboard:v1.5.0-rc.0
 requires:
   ingress:
     interface: ingress

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -40,7 +40,6 @@ async def test_build_and_deploy(ops_test):
 @pytest.mark.abort_on_fail
 async def test_add_profile_relation(ops_test):
     charm_name = METADATA["name"]
-    # TODO: Point kubeflow-profiles to latest/stable when Rev 54 or higher are promoted
     await ops_test.model.deploy("kubeflow-profiles", channel="latest/edge")
     await ops_test.model.add_relation("kubeflow-profiles", charm_name)
     await ops_test.model.wait_for_idle(


### PR DESCRIPTION
- Updated the upstream image version to 1.5.0
- Updated charmcraft python packages to use versions other than `setuptools 62.2.0` and `pip 22.1`
- Updated the CI to test on microk8s 1.22

---
Tests:
1. Deploy full bundle on microk8s 1.21 (both rbac disabled and enabled) with updated kubeflow-profiles and kubeflow-dashboard v1.5 - OK
- all charms are active
- access and login to dashboard - OK

2. Deploy kubeflow-profiles and kubeflow-dashboard on microk8s v1.22 - OK
Note: if kubeflow-dashboard is deployed on microk8s v1.22, it requires kubeflow-profiles 1.5 (`latest/edge`) since `latest/stable` uses CRDs that aren't supported in k8s v1.22.

3. Integration and unit tests (run on microk8s 1.21 and 1.22) - OK