### PR TITLE
feat: dynamically set test dependencies via bundle file

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -53,6 +53,11 @@ jobs:
   deploy:
     name: Integration Test
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dependency_context:
+          - https://raw.githubusercontent.com/canonical/bundle-kubeflow/master/releases/1.4/edge/kubeflow/bundle.yaml
+          - https://raw.githubusercontent.com/canonical/bundle-kubeflow/master/releases/1.4/latest/kubeflow/bundle.yaml
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -74,7 +79,7 @@ jobs:
           # https://github.com/kubeflow/kubeflow/issues/6136
           juju add-model kubeflow
           sudo apt install -y firefox-geckodriver
-          sg microk8s -c "tox -e integration -- --model kubeflow"
+          sg microk8s -c "tox -e integration -- --model kubeflow --version-bundle-uri ${{ matrix.dependency_context }}"
 
       - name: Get all
         run: kubectl get all -A

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         dependency_context:
           - https://raw.githubusercontent.com/canonical/bundle-kubeflow/master/releases/1.4/edge/kubeflow/bundle.yaml
-          - https://raw.githubusercontent.com/canonical/bundle-kubeflow/master/releases/1.4/latest/kubeflow/bundle.yaml
+          - https://raw.githubusercontent.com/canonical/bundle-kubeflow/master/releases/1.4/stable/kubeflow/bundle.yaml
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,62 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from collections import defaultdict
+import urllib.request
+
+import pytest
+from _pytest.config.argparsing import Parser
+import yaml
+
+
+def pytest_addoption(parser: Parser):
+    parser.addoption(
+        "--version-bundle-uri",
+        help="A uri to a charm bundle.yaml file that defines reference charm versions to be used "
+        "during this test.  Typically used to dynamically define the versions of the external"
+        " dependencies used during integration tests.  This can be an internet url, such as "
+        "a link to a github raw file, or a local file using file:./some/relative/file. "
+        "If any required charms are omitted, or if this option is omitted entirely, charms "
+        "will be deployed from the CharmHub default track.",
+    )
+
+
+@pytest.fixture(scope="session")
+def dependency_version_map(request) -> defaultdict:
+    """Yields a defaultdict of {charm_name: charm_channel} according to a loaded bundle file.
+
+    For any undefined charm_name, the defaultdict returns None, which will map a charm deploy to
+    the stable risk of the charm's default channel in CharmHub
+    """
+
+    # The default value returned if not set in the bundle is None, which means we use the stable
+    # risk of the charm's default channel in CharmHub
+    version_map = defaultdict(lambda: None)
+
+    bundle_uri = request.config.option.version_bundle_uri
+
+    if bundle_uri is not None:
+        bundle = fetch_bundle(bundle_uri)
+        # Note: A bundle could in theory use multiple versions of the same charm, named differently.
+        #       eg: spark-old pulls from ch:spark/old/latest, and spark-new pulls from
+        #       ch:spark/new/latest.  We ignore this here and just take the last channel used for a
+        #       given charm.
+        for application in bundle["applications"].values():
+            version_map[application["charm"]] = application["channel"]
+
+    yield version_map
+
+
+def fetch_bundle(uri: str, max_characters: int = 50000) -> dict:
+    """Fetch a bundle.yaml from an uri
+
+    Args:
+        uri (str): uri to fetch bundle from.  Can be https://, file:./some/file (relative),
+                   file:///some/file (absolute), etc.
+        max_characters (int): Maximum number of characters loaded from the uri (to prevent
+                              accidentally loading something enormous)
+
+    Returns: a rendered bundle.yaml file as a dict
+    """
+    data_stream = urllib.request.urlopen(uri).read(max_characters)
+    return yaml.safe_load(data_stream)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -38,9 +38,15 @@ async def test_build_and_deploy(ops_test):
 
 
 @pytest.mark.abort_on_fail
-async def test_add_profile_relation(ops_test):
+async def test_add_profile_relation(ops_test, dependency_version_map):
     charm_name = METADATA["name"]
-    await ops_test.model.deploy("kubeflow-profiles", channel="latest/edge")
+    print(
+        f"This test is dynamically pulling dependency versions from this map:\n"
+        f"{dependency_version_map=}"
+    )
+    await ops_test.model.deploy(
+        "kubeflow-profiles", channel=dependency_version_map["kubeflow-profiles"]
+    )
     await ops_test.model.add_relation("kubeflow-profiles", charm_name)
     await ops_test.model.wait_for_idle(
         ["kubeflow-profiles", charm_name],


### PR DESCRIPTION
This PR demonstrates a way to dynamically change the `channel` of any charms used as dependencies by passing the desired channels via a bundle file (either a local file or a url, such as to a [raw kubeflow-bundle release](https://raw.githubusercontent.com/canonical/bundle-kubeflow/master/releases/1.4/edge/kubeflow/bundle.yaml).

Added here are:
* a command line argument `--version-bundle-uri someUrl`, which accepts an address of a bundle.yaml formatted file (such as a `https://`, `file:./relative/file`, etc)
* Modifies the integration tests that need dependencies (see [test_add_profile_relation](https://github.com/canonical/kubeflow-dashboard-operator/blob/2039f856f6a9819287e84f0fcd5ba87898bd2ee6/tests/integration/test_charm.py#L41)) to look up the `channel` for each dependency from the above bundle.  If not found, the CharmHub default channel is used
* A [CI matrix](https://github.com/canonical/kubeflow-dashboard-operator/blob/2039f856f6a9819287e84f0fcd5ba87898bd2ee6/.github/workflows/integrate.yaml#L58) that points to the 1.4 edge and stable bundles.  This gives us integration tests in the context of each of those bundles (eg: tests kubeflow-dashboard using both kubeflow-profile 1.4/edge and 1.4/stable)