### PR TITLE
feat: dynamic sidebar content

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,3 +20,6 @@ requires:
     interface: k8s-service
     schema: https://raw.githubusercontent.com/canonical/operator-schemas/master/k8s-service.yaml
     versions: [v1]
+  sidepanel:
+    interface: sidepanel
+    optional: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-ops==1.2.0
+ops==1.3.0
 oci-image==1.0.0
 serialized-data-interface<0.4

--- a/src/charm.py
+++ b/src/charm.py
@@ -43,9 +43,7 @@ class Operator(CharmBase):
         self.log = logging.getLogger(__name__)
         self.image = OCIImageResource(self, "oci-image")
         self._stored.set_default(hash_salt=_gen_pass())
-        self._stored.set_default(
-            side_bar_tabs=Path("src/config.json").read_text()
-        )
+        self._stored.set_default(side_bar_tabs=Path("src/config.json").read_text())
 
         for event in [
             self.on.install,

--- a/src/config.json
+++ b/src/config.json
@@ -7,12 +7,6 @@
         },
         {
             "type": "item",
-            "link": "/katib/",
-            "text": "Experiments (AutoML)",
-            "icon": "kubeflow:katib"
-        },
-        {
-            "type": "item",
             "text": "Experiments (KFP)",
             "link": "/pipeline/#/experiments",
             "icon": "done-all"
@@ -40,12 +34,6 @@
             "link": "/volumes/",
             "text": "Volumes",
             "icon": "device:storage"
-        },
-        {
-          "type": "item",
-          "link": "/tensorboards/",
-          "text": "Tensorboards",
-          "icon": "assessment"
         }
     ],
     "externalLinks": [],

--- a/src/extra_config.json
+++ b/src/extra_config.json
@@ -1,0 +1,18 @@
+{
+    "katib-ui": {
+        "menuLink": {
+            "type": "item",
+            "link": "/katib/",
+            "text": "Experiments (AutoML)",
+            "icon": "kubeflow:katib"
+        }
+    },
+    "tensorboards-web-app": {
+        "menuLink": {
+            "type": "item",
+            "link": "/tensorboards/",
+            "text": "Tensorboards",
+            "icon": "assessment"
+        }
+    }
+}

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -108,7 +108,7 @@ def test_links(driver):
     # Ensure that sidebar links are set up properly
     links = [
         "/jupyter/",
-        "/katib/",
+        # "/katib/",  # katib no longer available in default sidebar
         "/pipeline/#/experiments",
         "/pipeline/#/pipelines",
         "/pipeline/#/runs",
@@ -117,7 +117,7 @@ def test_links(driver):
         # "/pipeline/#/artifacts",
         # "/pipeline/#/executions",
         "/volumes/",
-        "/tensorboards/",
+        # "/tensorboards/", # tensorboards no longer available in default sidebar
     ]
 
     for link in links:


### PR DESCRIPTION
Related to this [jira task](https://warthogs.atlassian.net/browse/KF-567?atlOrigin=eyJpIjoiN2M3MjQwZmY2NzEwNGQwMTkzYThkZTNhMzU0YmFlNmUiLCJwIjoiaiJ9) and #8 

There is a `sidebar` relation with the `src/extra_config.json`. In order to add element to the sidebar proper relation needs to be established. After the relation is set, charms fills the config for given app-name from `src/extra_config.json` and reloads the configmap. Currently supporting (juju application names)

- **katib-ui** for katib
- **tensorboards-web-app** for tesorboard

Sidebar element is removed after the relation is broken.

Prerequisites:
- [Katib PR] (https://github.com/canonical/katib-operators/pull/8)
- [Tensoorboards PR] (https://github.com/canonical/kubeflow-tensorboards-operator/pull/16)

Setup:
- deploy `katib` and `tensorboards`
- deploy dashboard `juju deploy ./*.charm --resource oci-image=$(yq eval '.resources.oci-image.upstream-source' metadata.yaml)`
- relate tensorboard `juju relate tensorboards-web-app:sidepanel kubeflow-dashboard:sidepanel`
- relate katib `juju relate katib-ui:sidepanel kubeflow-dashboard:sidepanel`
