### PR TITLE
fix: use pytest_asyncio.fixture so tests work w/asyncio-mode=strict

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -6,6 +6,7 @@ from subprocess import check_output
 from time import sleep
 
 import pytest
+import pytest_asyncio
 import yaml
 from selenium import webdriver
 from selenium.common.exceptions import JavascriptException, WebDriverException
@@ -71,7 +72,7 @@ def fix_queryselector(elems):
     return 'return document.querySelector("' + selectors + '")'
 
 
-@pytest.fixture()
+@pytest_asyncio.fixture
 async def driver(request, ops_test):
     status = yaml.safe_load(
         check_output(


### PR DESCRIPTION
This fixes the integration tests for `pytest-asyncio` `v0.19.0`, as described [here](https://github.com/canonical/kubeflow-dashboard-operator/pull/34#discussion_r938242618) and [here](https://github.com/canonical/bundle-kubeflow/issues/470)