### PR TITLE
feat: remove admin profile

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,10 +6,6 @@ options:
     type: int
     default: 8082
     description: HTTP port
-  profile:
-    type: string
-    default: admin
-    description: Kubeflow Profile to create
   dashboard-configmap:
     type: string
     default: centraldashboard-config

--- a/lib/charms/observability_libs/v1/kubernetes_service_patch.py
+++ b/lib/charms/observability_libs/v1/kubernetes_service_patch.py
@@ -9,21 +9,20 @@ service named after the application in the namespace (named after the Juju model
 default contains a "placeholder" port, which is 65536/TCP.
 
 When modifying the default set of resources managed by Juju, one must consider the lifecycle of the
-charm. In this case, any modifications to the default service (created during deployment), will
-be overwritten during a charm upgrade.
+charm. In this case, any modifications to the default service (created during deployment), will be
+overwritten during a charm upgrade.
 
 When initialised, this library binds a handler to the parent charm's `install` and `upgrade_charm`
 events which applies the patch to the cluster. This should ensure that the service ports are
 correct throughout the charm's life.
 
-The constructor simply takes a reference to the parent charm, and a list of tuples that each define
-a port for the service, where each tuple contains:
+The constructor simply takes a reference to the parent charm, and a list of
+[`lightkube`](https://github.com/gtsystem/lightkube) ServicePorts that each define a port for the
+service. For information regarding the `lightkube` `ServicePort` model, please visit the
+`lightkube` [docs](https://gtsystem.github.io/lightkube-models/1.23/models/core_v1/#serviceport).
 
-- a name for the port
-- port for the service to listen on
-- optionally: a targetPort for the service (the port in the container!)
-- optionally: a nodePort for the service (for NodePort or LoadBalancer services only!)
-- optionally: a name of the service (in case service name needs to be patched as well)
+Optionally, a name of the service (in case service name needs to be patched as well), labels,
+selectors, and annotations can be provided as keyword arguments.
 
 ## Getting Started
 
@@ -32,8 +31,8 @@ that you also need to add `lightkube` and `lightkube-models` to your charm's `re
 
 ```shell
 cd some-charm
-charmcraft fetch-lib charms.observability_libs.v0.kubernetes_service_patch
-echo <<-EOF >> requirements.txt
+charmcraft fetch-lib charms.observability_libs.v1.kubernetes_service_patch
+cat << EOF >> requirements.txt
 lightkube
 lightkube-models
 EOF
@@ -41,29 +40,52 @@ EOF
 
 Then, to initialise the library:
 
-For ClusterIP services:
+For `ClusterIP` services:
+
 ```python
 # ...
-from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
+from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
+from lightkube.models.core_v1 import ServicePort
 
 class SomeCharm(CharmBase):
   def __init__(self, *args):
     # ...
-    self.service_patcher = KubernetesServicePatch(self, [(f"{self.app.name}", 8080)])
+    port = ServicePort(443, name=f"{self.app.name}")
+    self.service_patcher = KubernetesServicePatch(self, [port])
     # ...
 ```
 
-For LoadBalancer/NodePort services:
+For `LoadBalancer`/`NodePort` services:
+
 ```python
 # ...
-from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
+from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
+from lightkube.models.core_v1 import ServicePort
 
 class SomeCharm(CharmBase):
   def __init__(self, *args):
     # ...
+    port = ServicePort(443, name=f"{self.app.name}", targetPort=443, nodePort=30666)
     self.service_patcher = KubernetesServicePatch(
-        self, [(f"{self.app.name}", 443, 443, 30666)], "LoadBalancer"
+        self, [port], "LoadBalancer"
     )
+    # ...
+```
+
+Port protocols can also be specified. Valid protocols are `"TCP"`, `"UDP"`, and `"SCTP"`
+
+```python
+# ...
+from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
+from lightkube.models.core_v1 import ServicePort
+
+class SomeCharm(CharmBase):
+  def __init__(self, *args):
+    # ...
+    tcp = ServicePort(443, name=f"{self.app.name}-tcp", protocol="TCP")
+    udp = ServicePort(443, name=f"{self.app.name}-udp", protocol="UDP")
+    sctp = ServicePort(443, name=f"{self.app.name}-sctp", protocol="SCTP")
+    self.service_patcher = KubernetesServicePatch(self, [tcp, udp, sctp])
     # ...
 ```
 
@@ -83,9 +105,10 @@ def setUp(self, *unused):
 
 import logging
 from types import MethodType
-from typing import Literal, Sequence, Tuple, Union
+from typing import List, Literal
 
 from lightkube import ApiError, Client
+from lightkube.core import exceptions
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
@@ -99,13 +122,12 @@ logger = logging.getLogger(__name__)
 LIBID = "0042f86d0a874435adef581806cddbbb"
 
 # Increment this major API version when introducing breaking changes
-LIBAPI = 0
+LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 6
+LIBPATCH = 3
 
-PortDefinition = Union[Tuple[str, int], Tuple[str, int, int], Tuple[str, int, int, int]]
 ServiceType = Literal["ClusterIP", "LoadBalancer"]
 
 
@@ -115,7 +137,7 @@ class KubernetesServicePatch(Object):
     def __init__(
         self,
         charm: CharmBase,
-        ports: Sequence[PortDefinition],
+        ports: List[ServicePort],
         service_name: str = None,
         service_type: ServiceType = "ClusterIP",
         additional_labels: dict = None,
@@ -126,7 +148,7 @@ class KubernetesServicePatch(Object):
 
         Args:
             charm: the charm that is instantiating the library.
-            ports: a list of tuples (name, port, targetPort, nodePort) for every service port.
+            ports: a list of ServicePorts
             service_name: allows setting custom name to the patched service. If none given,
                 application name will be used.
             service_type: desired type of K8s service. Default value is in line with ServiceSpec's
@@ -157,7 +179,7 @@ class KubernetesServicePatch(Object):
 
     def _service_object(
         self,
-        ports: Sequence[PortDefinition],
+        ports: List[ServicePort],
         service_name: str = None,
         service_type: ServiceType = "ClusterIP",
         additional_labels: dict = None,
@@ -167,10 +189,7 @@ class KubernetesServicePatch(Object):
         """Creates a valid Service representation.
 
         Args:
-            ports: a list of tuples of the form (name, port) or (name, port, targetPort)
-                or (name, port, targetPort, nodePort) for every service port. If the 'targetPort'
-                is omitted, it is assumed to be equal to 'port', with the exception of NodePort
-                and LoadBalancer services, where all port numbers have to be specified.
+            ports: a list of ServicePorts
             service_name: allows setting custom name to the patched service. If none given,
                 application name will be used.
             service_type: desired type of K8s service. Default value is in line with ServiceSpec's
@@ -203,15 +222,7 @@ class KubernetesServicePatch(Object):
             ),
             spec=ServiceSpec(
                 selector=selector,
-                ports=[
-                    ServicePort(
-                        name=p[0],
-                        port=p[1],
-                        targetPort=p[2] if len(p) > 2 else p[1],  # type: ignore[misc]
-                        nodePort=p[3] if len(p) > 3 else None,  # type: ignore[arg-type, misc]
-                    )
-                    for p in ports
-                ],
+                ports=ports,
                 type=service_type,
             ),
         )
@@ -222,11 +233,15 @@ class KubernetesServicePatch(Object):
         Raises:
             PatchFailed: if patching fails due to lack of permissions, or otherwise.
         """
-        if not self.charm.unit.is_leader():
+        try:
+            client = Client()
+        except exceptions.ConfigError as e:
+            logger.warning("Error creating k8s client: %s", e)
             return
 
-        client = Client()
         try:
+            if self._is_patched(client):
+                return
             if self.service_name != self._app:
                 self._delete_and_create_service(client)
             client.patch(Service, self.service_name, self.service, patch_type=PatchType.MERGE)
@@ -252,12 +267,25 @@ class KubernetesServicePatch(Object):
             bool: A boolean indicating if the service patch has been applied.
         """
         client = Client()
+        return self._is_patched(client)
+
+    def _is_patched(self, client: Client) -> bool:
         # Get the relevant service from the cluster
-        service = client.get(Service, name=self.service_name, namespace=self._namespace)
+        try:
+            service = client.get(Service, name=self.service_name, namespace=self._namespace)
+        except ApiError as e:
+            if e.status.code == 404 and self.service_name != self._app:
+                return False
+            else:
+                logger.error("Kubernetes service get failed: %s", str(e))
+                raise
+
         # Construct a list of expected ports, should the patch be applied
         expected_ports = [(p.port, p.targetPort) for p in self.service.spec.ports]
         # Construct a list in the same manner, using the fetched service
-        fetched_ports = [(p.port, p.targetPort) for p in service.spec.ports]  # type: ignore[attr-defined]  # noqa: E501
+        fetched_ports = [
+            (p.port, p.targetPort) for p in service.spec.ports  # type: ignore[attr-defined]
+        ]  # noqa: E501
         return expected_ports == fetched_ports
 
     @property

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,18 +4,23 @@
 
 import json
 import logging
-import traceback
 
 from pathlib import Path
 
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
-from charms.observability_libs.v0.kubernetes_service_patch import KubernetesServicePatch
+from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
+from lightkube.models.core_v1 import ServicePort
 from lightkube import ApiError
 from lightkube.generic_resource import load_in_cluster_generic_resources
 from ops.charm import CharmBase
 from ops.main import main
-from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
+from ops.model import (
+    ActiveStatus,
+    BlockedStatus,
+    MaintenanceStatus,
+    WaitingStatus,
+)
 from ops.pebble import ChangeError, Layer
 from serialized_data_interface import (
     NoCompatibleVersions,
@@ -23,12 +28,13 @@ from serialized_data_interface import (
     get_interfaces,
 )
 
-BASE_SIDEBAR = Path("src/config/sidebar_config.json").read_text()
-DEFAULT_RESOURCE_FILES = {
-    "profiles": "src/templates/profile_crds.yaml.j2",
-    "auths": "src/templates/auth_manifests.yaml.j2",
-    "config_maps": "src/templates/configmaps.yaml.j2",
-}
+BASE_SIDEBAR = json.loads(Path("src/config/sidebar_config.json").read_text())
+K8S_RESOURCE_FILES = [
+    "src/templates/profile_crds.yaml.j2",
+    "src/templates/auth_manifests.yaml.j2",
+]
+CONFIGMAP_FILE = "src/templates/configmaps.yaml.j2"
+SIDEBAR_RELATION_NAME = "sidebar"
 
 
 class CheckFailed(Exception):
@@ -56,19 +62,18 @@ class KubeflowDashboardOperator(CharmBase):
         self._service = "npm start"
         self._container_name = "kubeflow-dashboard"
         self._container = self.unit.get_container(self._name)
-        self._resource_files = DEFAULT_RESOURCE_FILES
         self._context = {
             "app_name": self._name,
             "namespace": self._namespace,
-            "configmap_name": self.model.config["dashboard-configmap"],
-            "profilename": self.model.config["profile"],
-            "links": BASE_SIDEBAR,
+            "configmap_name": self.configmap_name,
+            "profilename": self.profilename,
+            "links": json.dumps(BASE_SIDEBAR),
             "settings": json.dumps({"DASHBOARD_FORCE_IFRAME": True}),
         }
         self._k8s_resource_handler = None
-        self.service_patcher = KubernetesServicePatch(
-            self, [(self._container_name, self.model.config["port"])]
-        )
+        self._configmap_handler = None
+        port = ServicePort(int(self.port), name=f"{self.app.name}")
+        self.service_patcher = KubernetesServicePatch(self, [port])
         for event in [
             self.on.install,
             self.on.leader_elected,
@@ -79,7 +84,23 @@ class KubeflowDashboardOperator(CharmBase):
             self.on.kubeflow_dashboard_pebble_ready,
         ]:
             self.framework.observe(event, self.main)
-            self.framework.observe(self.on.remove, self._on_remove)
+        self.framework.observe(self.on.remove, self._on_remove)
+
+    @property
+    def configmap_name(self):
+        return self.model.config["dashboard-configmap"]
+
+    @property
+    def profilename(self):
+        return self.model.config["profile"]
+
+    @property
+    def port(self):
+        return self.model.config["port"]
+
+    @property
+    def registration_flow(self):
+        return self.model.config["registration-flow"]
 
     @property
     def profiles_service(self):
@@ -98,7 +119,7 @@ class KubeflowDashboardOperator(CharmBase):
         if not self._k8s_resource_handler:
             self._k8s_resource_handler = KubernetesResourceHandler(
                 field_manager=self._lightkube_field_manager,
-                template_files=self._resource_files.values(),
+                template_files=K8S_RESOURCE_FILES,
                 context=self._context,
                 logger=self.logger,
             )
@@ -108,6 +129,22 @@ class KubeflowDashboardOperator(CharmBase):
     @k8s_resource_handler.setter
     def k8s_resource_handler(self, handler: KubernetesResourceHandler):
         self._k8s_resource_handler = handler
+
+    @property
+    def configmap_handler(self):
+        if not self._configmap_handler:
+            self._configmap_handler = KubernetesResourceHandler(
+                field_manager=self._lightkube_field_manager,
+                template_files=[CONFIGMAP_FILE],
+                context=self._context,
+                logger=self.logger,
+            )
+        load_in_cluster_generic_resources(self._k8s_resource_handler.lightkube_client)
+        return self._configmap_handler
+
+    @configmap_handler.setter
+    def configmap_handler(self, handler: KubernetesResourceHandler):
+        self._configmap_handler = handler
 
     @property
     def _kubeflow_dashboard_operator_layer(self) -> Layer:
@@ -124,10 +161,8 @@ class KubeflowDashboardOperator(CharmBase):
                         "USERID_HEADER": "kubeflow-userid",
                         "USERID_PREFIX": "",
                         "PROFILES_KFAM_SERVICE_HOST": f"{self.profiles_service}.{self.model.name}",
-                        "REGISTRATION_FLOW": self.model.config["registration-flow"],
-                        "DASHBOARD_LINKS_CONFIGMAP": self.model.config[
-                            "dashboard-configmap"
-                        ],
+                        "REGISTRATION_FLOW": self.registration_flow,
+                        "DASHBOARD_CONFIGMAP": self.configmap_name,
                     },
                 }
             },
@@ -155,7 +190,6 @@ class KubeflowDashboardOperator(CharmBase):
         """Updates the Pebble configuration layer if changed."""
         current_layer = self.container.get_plan()
         new_layer = self._kubeflow_dashboard_operator_layer
-        self.logger.debug(f"NEW LAYER: {new_layer}")
         if current_layer.services != new_layer.services:
             self.unit.status = MaintenanceStatus("Applying new pebble layer")
             self.container.add_layer(self._container_name, new_layer, combine=True)
@@ -176,14 +210,14 @@ class KubeflowDashboardOperator(CharmBase):
             raise CheckFailed(err, BlockedStatus)
         return interfaces
 
-    def handle_ingress(self, interfaces):
+    def _handle_ingress(self, interfaces):
         if interfaces["ingress"]:
             interfaces["ingress"].send_data(
                 {
                     "prefix": "/",
                     "rewrite": "/",
                     "service": self.model.app.name,
-                    "port": self.model.config["port"],
+                    "port": self.port,
                 }
             )
 
@@ -197,6 +231,15 @@ class KubeflowDashboardOperator(CharmBase):
 
         return kf_profiles
 
+    def _deploy_k8s_resources(self) -> None:
+        try:
+            self.unit.status = MaintenanceStatus("Creating k8s resources")
+            self.k8s_resource_handler.apply()
+            self.configmap_handler.apply()
+        except ApiError:
+            raise CheckFailed("kubernetes resource creation failed", BlockedStatus)
+        self.model.unit.status = ActiveStatus()
+
     def _get_data_from_profiles_interface(self, kf_profiles_interface):
         return list(kf_profiles_interface.get_data().values())[0]
 
@@ -208,21 +251,10 @@ class KubeflowDashboardOperator(CharmBase):
             self._check_leader()
             interfaces = self._get_interfaces()
             kf_profiles_interface = self._check_kf_profiles(interfaces)
-            self.handle_ingress(interfaces)
-        except CheckFailed as e:
-            self.model.unit.status = e.status
-            return
-        try:
-            self.unit.status = MaintenanceStatus("Creating k8s resources")
-            self.k8s_resource_handler.apply()
-        except ApiError:
-            self.logger.error(traceback.format_exc())
-            self.unit.status = BlockedStatus("kubernetes resource creation failed")
-            return
-        self.handle_ingress(interfaces)
-        kf_profiles = self._get_data_from_profiles_interface(kf_profiles_interface)
-        self.profiles_service = kf_profiles["service-name"]
-        try:
+            self._handle_ingress(interfaces)
+            self._deploy_k8s_resources()
+            kf_profiles = self._get_data_from_profiles_interface(kf_profiles_interface)
+            self.profiles_service = kf_profiles["service-name"]
             self._update_layer()
         except CheckFailed as e:
             self.model.unit.status = e.status
@@ -231,12 +263,15 @@ class KubeflowDashboardOperator(CharmBase):
 
     def _on_remove(self, _):
         self.unit.status = MaintenanceStatus("Removing k8s resources")
-        self.k8s_resource_handler._template_files = DEFAULT_RESOURCE_FILES.values()
-        manifests = self.k8s_resource_handler.render_manifests()
+        k8s_resources_manifests = self.k8s_resource_handler.render_manifests()
+        configmap_manifest = self.configmap_handler.render_manifests()
         try:
-            delete_many(self.k8s_resource_handler.lightkube_client, manifests)
+            delete_many(
+                self.k8s_resource_handler.lightkube_client, k8s_resources_manifests
+            )
+            delete_many(self.configmap_handler.lightkube_client, configmap_manifest)
         except ApiError as e:
-            self.logger.warning(f"Failed to delete resources: {manifests} with: {e}")
+            self.logger.warning(f"Failed to delete resources, with error: {e}")
             raise e
         self.unit.status = MaintenanceStatus("K8s resources removed")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -30,7 +30,6 @@ from serialized_data_interface import (
 
 BASE_SIDEBAR = json.loads(Path("src/config/sidebar_config.json").read_text())
 K8S_RESOURCE_FILES = [
-    "src/templates/profile_crds.yaml.j2",
     "src/templates/auth_manifests.yaml.j2",
 ]
 CONFIGMAP_FILE = "src/templates/configmaps.yaml.j2"

--- a/src/templates/profile_crds.yaml.j2
+++ b/src/templates/profile_crds.yaml.j2
@@ -1,8 +1,0 @@
-apiVersion: kubeflow.org/v1
-kind: Profile
-metadata:
-  name: {{ profilename }}
-spec:
-  owner:
-    kind: User
-    name: {{ profilename }}


### PR DESCRIPTION
Besides removing the admin profile from the charm, this PR also adds refactoring already approved in #38 (its in different branch right now but we may need it sooner)

**Important**: I deployed the latest/edge bundle and run the examples in https://charmed-kubeflow.io/docs/kubeflow-basics I think we don't need the default admin profile (which is user profile with admin name). On every first time login (e.g. user123) the dashboard directly creates a user with the same profile. 