### PR TITLE
use chisme pebble update_layer

### DIFF
--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -202,7 +202,7 @@ class TestCharm:
 
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     @patch("charm.KubeflowDashboardOperator.k8s_resource_handler")
-    @patch("charm.KubeflowDashboardOperator._update_layer")
+    @patch("charm.update_layer")
     def test_main(
         self,
         update_layer: MagicMock,


### PR DESCRIPTION
Update dashboard-operator to use the `update_layer` function in chisme, updated tests to match
CI would fail until [this pr](https://github.com/canonical/charmed-kubeflow-chisme/pull/25) is merged and published. Tested locally with `git+https://github.com/canonical/charmed-kubeflow-chisme@KF-605/update-layer-handler` in `requirements.txt`