### PR TITLE
chore: oci image version bump 1.6.0-rc.2 -> 1.6.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,7 +10,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.6.0-rc.2
+    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.6.0
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Version bump to 1.6.0 release image

NOTE: this PR depends on the latest image tag specified in [kubeflow/manifests](https://github.com/kubeflow/manifests/blob/v1.6-branch/apps/admission-webhook/upstream