### PR TITLE
[cherry-pick] 44518e and 50cf643

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/kubeflow

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,7 +10,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.6.0-rc.1
+    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.6.0-rc.2
 requires:
   ingress:
     interface: ingress


### PR DESCRIPTION
Backporting 
[[skip ci] git-xargs programmatic commit](https://github.com/canonical/kubeflow-dashboard-operator/commit/445184e204797ad42c234f33f0c2ff5829e71821)
[chore: Bump image versions](https://github.com/canonical/kubeflow-dashboard-operator/commit/50cf6436f432b225b0e95b1ebb88b3118d521be0)
