### PR TITLE
fix: pin github runners to ubuntu-20.04

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,7 +10,7 @@ jobs:
 
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -24,7 +24,7 @@ jobs:
 
   lint:
     name: Lint Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out code
@@ -38,7 +38,7 @@ jobs:
 
   unit:
     name: Unit Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - name: Check out code
@@ -52,7 +52,7 @@ jobs:
 
   deploy:
     name: Integration Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -28,7 +28,7 @@ on:
 jobs:
   get-charm-paths:
     name: Generate the Charm Matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     outputs:
       charm_paths_list: ${{ steps.get-charm-paths.outputs.CHARM_PATHS_LIST }}
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   publish-charm:
     name: Publish Charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: get-charm-paths
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   promote-charm:
     name: Promote charm
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Release charm to channel


### PR DESCRIPTION
This pins github runners to ubuntu-20.04 because Github is rolling out ubuntu-22.04 to machines that request `ubuntu-latest`, and 22.04 causes test and build issues.