### PR TITLE
fix: pin juju agent version to 2.9.34 github runners to ubuntu-20.04

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -62,6 +62,11 @@ jobs:
             provider: microk8s
             channel: 1.22/stable
             charmcraft-channel: latest/candidate
+          # TODO: Unpin this when this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833.
+          #       In particular, these tests failed deploying the prometheus-k8s charm where it gets an error in
+          #       the "metrics-endpoint-relation-changed" hook.
+            bootstrap-options: --agent-version="2.9.34"
+
 
       # TODO: Remove once the actions-operator does this automatically
       - name: Configure kubectl


### PR DESCRIPTION
This is a temporary fix to address [this bug](https://bugs.launchpad.net/juju/+bug/1992833), which raises errors about the series of the charm being deployed.