### PR TITLE
fix: remove BlockedStatus statements in charm code

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -6,6 +6,7 @@ import json
 import logging
 from pathlib import Path
 
+from charmed_kubeflow_chisme.exceptions import GenericCharmRuntimeError
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
 from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
@@ -171,8 +172,8 @@ class KubeflowDashboardOperator(CharmBase):
             try:
                 self.logger.info("Pebble plan updated with new configuration, replaning")
                 self.container.replan()
-            except ChangeError:
-                raise CheckFailed("Failed to replan", BlockedStatus)
+            except ChangeError as e:
+                raise GenericCharmRuntimeError("Failed to replan") from e
 
     def _get_interfaces(self):
         try:
@@ -205,8 +206,8 @@ class KubeflowDashboardOperator(CharmBase):
             self.unit.status = MaintenanceStatus("Creating k8s resources")
             self.k8s_resource_handler.apply()
             self.configmap_handler.apply()
-        except ApiError:
-            raise CheckFailed("kubernetes resource creation failed", BlockedStatus)
+        except ApiError as e:
+            raise GenericCharmRuntimeError("Failed to create K8S resources") from e
         self.model.unit.status = ActiveStatus()
 
     def _get_data_from_profiles_interface(self, kf_profiles_interface):

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import yaml
+from charmed_kubeflow_chisme.exceptions import GenericCharmRuntimeError
 from lightkube import ApiError
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.pebble import ChangeError
@@ -162,8 +163,8 @@ class TestCharm:
     ):
         container.replan.side_effect = _FakeChangeError("Fake problem during layer update", None)
         harness_with_profiles.container_pebble_ready(CHARM_NAME)
-        harness_with_profiles.begin_with_initial_hooks()
-        assert harness_with_profiles.charm.model.unit.status == BlockedStatus("Failed to replan")
+        with pytest.raises(GenericCharmRuntimeError):
+            harness_with_profiles.begin_with_initial_hooks()
 
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     @patch("charm.KubeflowDashboardOperator.configmap_handler")


### PR DESCRIPTION
A BlockedStatus mean a human has to manually intervene to ublock the unit and let it proceed. There were some conditions where no external intervention could ublock the unit. Adding appropriate logging and exceptions to catch errors and set status correctly.

Fixes canonical/bundle-kubeflow#549

Merge after #110, CI error should be fixed after that.