### PR TITLE
fix: add missing LOGOUT_URL env variable

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -139,6 +139,7 @@ class KubeflowDashboardOperator(CharmBase):
                         "PROFILES_KFAM_SERVICE_HOST": f"{self.profiles_service}.{self.model.name}",
                         "REGISTRATION_FLOW": self._registration_flow,
                         "DASHBOARD_CONFIGMAP": self._configmap_name,
+                        "LOGOUT_URL": "/authservice/logout",
                     },
                 }
             },


### PR DESCRIPTION
Upstream recently added the variable to dynamically set the logout url. Setting this variable to make the logout button usable.

Fixes canonical/bundle-kubeflow#364