### PR TITLE
fix: put charm to Blocked status when missing relation to profiles

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -197,7 +197,12 @@ class KubeflowDashboardOperator(CharmBase):
             )
 
     def _check_kf_profiles(self, interfaces):
-        if not ((kf_profiles := interfaces["kubeflow-profiles"]) and kf_profiles.get_data()):
+        kf_profiles = interfaces["kubeflow-profiles"]
+
+        if not kf_profiles:
+            raise CheckFailed("Relation to kubeflow-profiles required", BlockedStatus)
+
+        if not kf_profiles.get_data():
             raise CheckFailed("Waiting for kubeflow-profiles relation data", WaitingStatus)
 
         return kf_profiles

--- a/src/charm.py
+++ b/src/charm.py
@@ -200,7 +200,7 @@ class KubeflowDashboardOperator(CharmBase):
         kf_profiles = interfaces["kubeflow-profiles"]
 
         if not kf_profiles:
-            raise CheckFailed("Relation to kubeflow-profiles required", BlockedStatus)
+            raise CheckFailed("Add required relation to kubeflow-profiles", BlockedStatus)
 
         if not kf_profiles.get_data():
             raise CheckFailed("Waiting for kubeflow-profiles relation data", WaitingStatus)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -93,7 +93,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     assert ops_test.model.applications[CHARM_NAME].units[0].workload_status == "blocked"
     assert (
         ops_test.model.applications[CHARM_NAME].units[0].workload_status_message
-        == "Relation to kubeflow-profiles required"
+        == "Add required relation to kubeflow-profiles"
     )
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -87,14 +87,13 @@ async def test_build_and_deploy(ops_test: OpsTest):
 
     await ops_test.model.wait_for_idle(
         [CHARM_NAME],
-        raise_on_blocked=True,
         raise_on_error=True,
         timeout=300,
     )
-    assert ops_test.model.applications[CHARM_NAME].units[0].workload_status == "waiting"
+    assert ops_test.model.applications[CHARM_NAME].units[0].workload_status == "blocked"
     assert (
         ops_test.model.applications[CHARM_NAME].units[0].workload_status_message
-        == "Waiting for kubeflow-profiles relation data"
+        == "Relation to kubeflow-profiles required"
     )
 
 
@@ -106,7 +105,6 @@ async def test_add_profile_relation(ops_test: OpsTest):
     await ops_test.model.wait_for_idle(
         [PROFILES_CHARM_NAME, CHARM_NAME],
         status="active",
-        raise_on_blocked=True,
         raise_on_error=True,
         timeout=300,
     )

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -140,7 +140,7 @@ class TestCharm:
         harness.begin_with_initial_hooks()
 
         assert harness.charm.model.unit.status == BlockedStatus(
-            "Relation to kubeflow-profiles required"
+            "Add required relation to kubeflow-profiles"
         )
 
     @patch("charm.KubernetesResourceHandler")

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -139,8 +139,8 @@ class TestCharm:
         harness.set_leader(True)
         harness.begin_with_initial_hooks()
 
-        assert harness.charm.model.unit.status == WaitingStatus(
-            "Waiting for kubeflow-profiles relation data"
+        assert harness.charm.model.unit.status == BlockedStatus(
+            "Relation to kubeflow-profiles required"
         )
 
     @patch("charm.KubernetesResourceHandler")


### PR DESCRIPTION
This change puts the charm into Blocked status when the profile relation is missing, but to Waiting when the relation exists but does not have data in it (presumably because we're just waiting on the profile charm to reply).

closes #97