### PR TITLE
[DO NOT MERGE] ci: bump quality checks version main -> dnplas-remove-charm-path

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,7 +10,7 @@ on:
 jobs:
   lib-check:
     name: Check libraries
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@dnplas-remove-charm-path
     secrets: inherit
     with:
         charm-path: "."


### PR DESCRIPTION
This PR tests the changes introduced by https://github.com/canonical/charmed-kubeflow-workflows/pull/17.