### PR TITLE
Add validation on `DashboardLink.location`

### DIFF
--- a/lib/charms/kubeflow_dashboard/v0/kubeflow_dashboard_links.py
+++ b/lib/charms/kubeflow_dashboard/v0/kubeflow_dashboard_links.py
@@ -106,6 +106,11 @@ class DashboardLink:
     type: str = "item"  # noqa: A003
     desc: str = ""
 
+    def __post_init__(self):
+        """Validate that location is one of the accepted values."""
+        if self.location not in DASHBOARD_LINK_LOCATIONS:
+            raise ValueError(f"location must be one of {DASHBOARD_LINK_LOCATIONS} - got '{self.location}'.")
+
 
 class KubeflowDashboardLinksUpdatedEvent(RelationEvent):
     """Indicates the Kubeflow Dashboard link data was updated."""

--- a/tests/unit/test_sidebar_lib.py
+++ b/tests/unit/test_sidebar_lib.py
@@ -1,7 +1,9 @@
 import json
+from contextlib import nullcontext as does_not_raise
 from dataclasses import asdict
 from typing import List
 
+import pytest
 from ops.charm import CharmBase
 from ops.testing import Harness
 
@@ -55,6 +57,29 @@ class DummyRequirerCharm(CharmBase):
             relation_name=RELATION_NAME,
             dashboard_links=REQUIRER_DASHBOARD_LINKS,
         )
+
+
+class TestDashboardLink:
+    @pytest.mark.parametrize(
+        "location, context_raised",
+        [
+            ("menu", does_not_raise()),
+            ("menu", does_not_raise()),
+            ("menu", does_not_raise()),
+            ("menu", does_not_raise()),
+            ("invalid-location", pytest.raises(ValueError)),
+        ],
+    )
+    def test_location_validation(self, location, context_raised):
+        with context_raised:
+            DashboardLink(
+                text="",
+                link="",
+                location=location,
+                icon="",
+                type="",
+                desc="",
+            )
 
 
 class TestProvider:


### PR DESCRIPTION
The `DashboardLink.location` field accepts only specific values.  This PR adds validation to assert that during runtime.  

Closes #131 