### PR TITLE
feat: images retrieval script (DO NOT MERGE, debug PR)

### DIFF
--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -6,6 +6,8 @@ name: On Pull Request
 
 on:
   pull_request:
+    paths-ignore:
+      - '**/tools'
 
 jobs:
 

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -7,7 +7,7 @@ name: On Pull Request
 on:
   pull_request:
     paths-ignore:
-      - '**/tools'
+      - 'tools/**'
 
 jobs:
 

--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# dynamic list
+IMAGE_LIST=()
+IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+printf "%s\n" "${IMAGE_LIST[@]}"
+


### PR DESCRIPTION
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup. Script is specific for track/1.7 branch to capture all images for that branch. Branch is handled in kubeflow-ci and bundle automation using bundle file.

Summary of changes:
- Re-designed get images script to retrieve all images for current branch. Branch management is done outside of this script.
- Updated workflow.