### PR TITLE
build: install jsonschema from binary instead of building from src

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -13,5 +13,10 @@ parts:
   charm:
     prime:
       - files/*yaml
-    # do not use these versions due to pypa/setuptools_scm#713
-    charm-python-packages: [ setuptools!=62.2.0, pip!=22.1 ]
+    charm-python-packages: [setuptools, pip]
+    # Workaround for https://github.com/python-jsonschema/jsonschema/issues/1114
+    # and https://github.com/crate-py/rpds/issues/6
+    # and https://github.com/python-jsonschema/jsonschema/issues/1117
+    # TODO: jsonschema is a dependency of SDI, once SDI is not used on this charm,
+    # this workaround can be removed
+    charm-binary-python-packages: [jsonschema]


### PR DESCRIPTION
Because some dependencies of jsonschema require the rust toolchain (see 1 and 2), building the charm fails when building and installing some deps of jsonschema. The workaround to this is to install jsonschema from binary, avoiding unnecesary toolchains in the charm and reducing the chance of getting affected by third party dependencies when they are updated.

##### Considerations
Other options were considered for fixing the issue, like installing `rustc` in the charm directly and pinning jsonschema<4.18. The first option seem too invasive as charms will not use rustc for anything during runtime. The last option restricted us from updating the package in the event of a bug fix or if a new version is needed.
Installing from binary also has limitations, such as version management, which is now done in `charmcraft.yaml` and not in the more common requirement files.

Fixes: #147 

[1]https://github.com/python-jsonschema/jsonschema/issues/1117 
[2] https://github.com/python-jsonschema/jsonschema/issues/1114