### PR TITLE
fix: Drop stale directory ref from charmcraft.yaml

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,6 +11,4 @@ bases:
       channel: "20.04"
 parts:
   charm:
-    prime:
-      - files/*yaml
     charm-python-packages: [setuptools, pip]


### PR DESCRIPTION
Remove reference to the `files` directory that doesn't exist anymore from the charmcraft.yaml file.

Closes #149