### PR TITLE
feat: get images on main

### DIFF
--- a/tools/get-images.sh
+++ b/tools/get-images.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# dynamic list
+IMAGE_LIST=()
+IMAGE_LIST+=($(find -type f -name metadata.yaml -exec yq '.resources | to_entries | .[] | .value | ."upstream-source"' {} \;))
+printf "%s\n" "${IMAGE_LIST[@]}"
+


### PR DESCRIPTION
For more details refer to the following issue: https://github.com/canonical/bundle-kubeflow/issues/679

Summary of changes:
- Added script that produces list of container images managed by charm in this repository. Image list is a dynamic list.