### PR TITLE
feat: update charm 1.8.0 rc.0

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -54,7 +54,7 @@ jobs:
         with:
             provider: microk8s
             channel: 1.25-strict/stable
-            microk8s-addons: "rbac ingress metallb:10.64.140.43-10.64.140.49"
+            microk8s-addons: "dns hostpath-storage rbac ingress metallb:10.64.140.43-10.64.140.49"
             juju-channel: 3.1/stable
             charmcraft-channel: latest/candidate
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -10,8 +10,7 @@ on:
 jobs:
   lib-check:
     name: Check libraries
-    # TODO: Pin this to a version once charmed-kubeflow-workflows has versioned release
-    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@f0e79034881a1b33a0742fa9a034c96a14652df2
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
     secrets: inherit
     with:
         charm-path: "."
@@ -54,19 +53,10 @@ jobs:
         uses: charmed-kubernetes/actions-operator@main
         with:
             provider: microk8s
-            channel: 1.24/stable
+            channel: 1.25-strict/stable
+            microk8s-addons: "rbac ingress metallb:10.64.140.43-10.64.140.49"
+            juju-channel: 3.1/stable
             charmcraft-channel: latest/candidate
-          # TODO: Unpin this when this bug is resolved: https://bugs.launchpad.net/juju/+bug/1992833.
-          #       In particular, these tests failed deploying the prometheus-k8s charm where it gets an error in
-          #       the "metrics-endpoint-relation-changed" hook.
-            bootstrap-options: --agent-version="2.9.34"
-      
-      - name: Configure microk8s
-        run: |
-          sg microk8s -c "microk8s enable rbac ingress metallb:10.64.140.43-10.64.140.49"
-          # Requires the model to be called kubeflow due to this bug:
-          # https://github.com/kubeflow/kubeflow/issues/6136
-          juju add-model kubeflow
 
       - name: Install Chrome driver
         run: |
@@ -76,7 +66,8 @@ jobs:
 
       - name: Run test
         run: |
-          sg microk8s -c "tox -e integration -- --model kubeflow"
+          juju add-model kubeflow
+          sg snap_microk8s -c "tox -e integration -- --model kubeflow"
 
       - name: Get juju status
         run: juju status

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,7 +11,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.7.0
+    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.8.0-rc.0
 provides:
   links:
     interface: kubeflow_dashboard_links

--- a/requirements-integration.in
+++ b/requirements-integration.in
@@ -1,6 +1,5 @@
-# Pinning to <3.0 to ensure compatibility with the 2.9 controller version
-# Note: 3.0 is not being maintained anymore
-juju<3.0
+# Pinning to <4.0 due to compatibility with the 3.1 controller version
+juju<4.0
 lightkube
 ops
 pytest

--- a/requirements-integration.txt
+++ b/requirements-integration.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile requirements-integration.in
 #
-anyio==3.7.1
+anyio==4.0.0
     # via httpcore
-asttokens==2.2.1
+asttokens==2.4.0
     # via stack-data
 attrs==23.1.0
     # via
@@ -19,7 +19,7 @@ bcrypt==4.0.1
     # via paramiko
 blinker==1.6.2
     # via selenium-wire
-brotli==1.0.9
+brotli==1.1.0
     # via selenium-wire
 cachetools==5.3.1
     # via google-auth
@@ -49,7 +49,7 @@ decorator==5.1.1
     #   ipython
 deepdiff==6.2.1
     # via charmed-kubeflow-chisme
-exceptiongroup==1.1.2
+exceptiongroup==1.1.3
     # via
     #   anyio
     #   pytest
@@ -71,6 +71,8 @@ httpcore==0.17.3
     # via httpx
 httpx==0.24.1
     # via lightkube
+hvac==1.2.0
+    # via juju
 hyperframe==6.0.1
     # via
     #   h2
@@ -97,12 +99,10 @@ jinja2==3.1.2
     #   pytest-operator
 jsonschema==4.17.3
     # via serialized-data-interface
-juju==2.9.44.0
+juju==3.2.2
     # via
     #   -r requirements-integration.in
     #   pytest-operator
-jujubundlelib==0.5.7
-    # via theblues
 kaitaistruct==0.10
     # via selenium-wire
 kubernetes==27.2.0
@@ -112,12 +112,10 @@ lightkube==0.14.0
     #   -r requirements-integration.in
     #   -r requirements.in
     #   charmed-kubeflow-chisme
-lightkube-models==1.27.1.4
+lightkube-models==1.28.1.4
     # via lightkube
 macaroonbakery==1.3.1
-    # via
-    #   juju
-    #   theblues
+    # via juju
 markupsafe==2.1.3
     # via jinja2
 matplotlib-inline==0.1.6
@@ -128,7 +126,7 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.5.0
+ops==2.6.0
     # via
     #   -r requirements-integration.in
     #   -r requirements.in
@@ -150,7 +148,7 @@ pickleshare==0.7.5
     # via ipython
 pkgutil-resolve-name==1.3.10
     # via jsonschema
-pluggy==1.2.0
+pluggy==1.3.0
     # via pytest
 prompt-toolkit==3.0.39
     # via ipython
@@ -172,6 +170,8 @@ pycparser==2.21
     # via cffi
 pygments==2.16.1
     # via ipython
+pyhcl==0.4.5
+    # via hvac
 pymacaroons==0.13.0
     # via macaroonbakery
 pynacl==1.5.0
@@ -193,7 +193,7 @@ pysocks==1.7.1
     # via
     #   selenium-wire
     #   urllib3
-pytest==7.4.0
+pytest==7.4.2
     # via
     #   -r requirements-integration.in
     #   pytest-asyncio
@@ -202,18 +202,17 @@ pytest-asyncio==0.21.1
     # via
     #   -r requirements-integration.in
     #   pytest-operator
-pytest-operator==0.28.0
+pytest-operator==0.29.0
     # via -r requirements-integration.in
 python-dateutil==2.8.2
     # via kubernetes
-pytz==2023.3
+pytz==2023.3.post1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
     #   -r requirements-integration.in
     #   -r requirements.in
     #   juju
-    #   jujubundlelib
     #   kubernetes
     #   lightkube
     #   ops
@@ -221,11 +220,11 @@ pyyaml==6.0.1
     #   serialized-data-interface
 requests==2.31.0
     # via
+    #   hvac
     #   kubernetes
     #   macaroonbakery
     #   requests-oauthlib
     #   serialized-data-interface
-    #   theblues
 requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
@@ -234,7 +233,7 @@ ruamel-yaml==0.17.32
     # via charmed-kubeflow-chisme
 ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
-selenium==4.11.2
+selenium==4.12.0
     # via
     #   -r requirements-integration.in
     #   selenium-wire
@@ -263,10 +262,8 @@ sortedcontainers==2.4.0
     # via trio
 stack-data==0.6.2
     # via ipython
-tenacity==8.2.2
+tenacity==8.2.3
     # via charmed-kubeflow-chisme
-theblues==0.5.2
-    # via juju
 tomli==2.0.1
     # via
     #   ipdb
@@ -281,7 +278,7 @@ trio==0.22.2
     # via
     #   selenium
     #   trio-websocket
-trio-websocket==0.10.3
+trio-websocket==0.10.4
     # via selenium
 typing-extensions==4.7.1
     # via
@@ -296,11 +293,11 @@ urllib3[socks]==2.0.4
     #   selenium
 wcwidth==0.2.6
     # via prompt-toolkit
-websocket-client==1.6.1
+websocket-client==1.6.2
     # via
     #   kubernetes
     #   ops
-websockets==7.0
+websockets==8.1
     # via juju
 wsproto==1.2.0
     # via

--- a/src/templates/auth_manifests.yaml.j2
+++ b/src/templates/auth_manifests.yaml.j2
@@ -18,7 +18,6 @@ rules:
   - app.k8s.io
   - kubeflow.org
   resources:
-  - profiles
   - applications
   - pods
   - pods/exec


### PR DESCRIPTION
## Summary of changes
- Bump image version to v1.8.0-rc.0 in preparation for the 1.8 release based on kubeflow/manifests repo tag v1.8.0-rc.0.
- Remove unused `profiles` resource from Auth manifests, this resource was needed for creating the `admin` profile, which is no longer applicable.