### PR TITLE
feat: update charm 1.8.0-rc.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,7 +11,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.7.0
+    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.8.0-rc.0
 provides:
   links:
     interface: kubeflow_dashboard_links

--- a/src/charm.py
+++ b/src/charm.py
@@ -170,7 +170,7 @@ class KubeflowDashboardOperator(CharmBase):
                         "REGISTRATION_FLOW": self._registration_flow,
                         "DASHBOARD_CONFIGMAP": self._configmap_name,
                         "LOGOUT_URL": "/authservice/logout",
-                        "POD_NAMESPACE": self.model.name,   # Added due to https://github.com/canonical/bundle-kubeflow/issues/698
+                        "POD_NAMESPACE": self.model.name,  # Added due to https://github.com/canonical/bundle-kubeflow/issues/698   # noqa E501
                     },
                 }
             },

--- a/src/charm.py
+++ b/src/charm.py
@@ -170,6 +170,7 @@ class KubeflowDashboardOperator(CharmBase):
                         "REGISTRATION_FLOW": self._registration_flow,
                         "DASHBOARD_CONFIGMAP": self._configmap_name,
                         "LOGOUT_URL": "/authservice/logout",
+                        "POD_NAMESPACE": self.model.name,   # Added due to https://github.com/canonical/bundle-kubeflow/issues/698
                     },
                 }
             },

--- a/src/templates/auth_manifests.yaml.j2
+++ b/src/templates/auth_manifests.yaml.j2
@@ -18,7 +18,6 @@ rules:
   - app.k8s.io
   - kubeflow.org
   resources:
-  - profiles
   - applications
   - pods
   - pods/exec

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -82,7 +82,7 @@ async def test_add_profile_relation(ops_test: OpsTest):
         [PROFILES_CHARM_NAME, CHARM_NAME],
         status="active",
         raise_on_error=True,
-        timeout=300,
+        timeout=600,
     )
 
 


### PR DESCRIPTION
## Summary of changes
- Bump image version to v1.8.0-rc.0 in preparation for the 1.8 release based on kubeflow/manifests repo tag v1.8.0-rc.0.
- Remove unused `profiles` resource from Auth manifests, this resource was needed for creating the `admin` profile, which is no longer applicable.
- Set the newly added `POD_NAMESPACE` env var, for context see the issue https://github.com/canonical/bundle-kubeflow/issues/698