### PR TITLE
add namespace to the ingress relation data

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -224,6 +224,7 @@ class KubeflowDashboardOperator(CharmBase):
                     "rewrite": "/",
                     "service": self.model.app.name,
                     "port": self._port,
+                    "namespace": self._namespace,
                 }
             )
 


### PR DESCRIPTION
Enables supporting cross-model ingresses.  The ingress relation supports an optional namespace parameter.  If not passed, istio-pilot uses its own namespace, which is invalid if istio and dashboard are deployed in different namespaces.