### PR TITLE
chore: use charmedkubeflow/kubeflow-central-dashboard as oci-image

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,7 +12,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: charmedkubeflow/kubeflow-central-dashboard:1.8-3abeabc
+    upstream-source: charmedkubeflow/kubeflow-central-dashboard:1.8-0719441
 provides:
   links:
     interface: kubeflow_dashboard_links

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,7 +12,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.8.0
+    upstream-source: charmedkubeflow/kubeflow-central-dashboard:1.8-3abeabc
 provides:
   links:
     interface: kubeflow_dashboard_links

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,7 +61,11 @@ class KubeflowDashboardOperator(CharmBase):
         self._lightkube_field_manager = "lightkube"
         self._profiles_service = None
         self._name = self.model.app.name
-        self._service = "/usr/bin/npm start --prefix /app"
+
+        # The service name must be consistent with the one defined in the rockcraft project
+        self._pebble_service_name = "serve"
+        self._pebble_service_command = "/usr/bin/npm start"
+
         self._container_name = "kubeflow-dashboard"
         self._container = self.unit.get_container(self._name)
         self._configmap_name = self.model.config["dashboard-configmap"]
@@ -158,10 +162,10 @@ class KubeflowDashboardOperator(CharmBase):
             "summary": "kubeflow-dashboard-operator layer",
             "description": "pebble config layer for kubeflow_dashboard_operator",
             "services": {
-                "serve": {
+                self._pebble_service_name: {
                     "override": "replace",
                     "summary": "entrypoint of the kubeflow_dashboard_operator image",
-                    "command": self._service,
+                    "command": self._pebble_service_command,
                     "startup": "enabled",
                     "environment": {
                         "NODE_ENV": "production",

--- a/src/charm.py
+++ b/src/charm.py
@@ -167,7 +167,7 @@ class KubeflowDashboardOperator(CharmBase):
                     "summary": "entrypoint of the kubeflow_dashboard_operator image",
                     "command": self._pebble_service_command,
                     "startup": "enabled",
-                    "working-dir": "/app"
+                    "working-dir": "/app",
                     "environment": {
                         "NODE_ENV": "production",
                         "USERID_HEADER": "kubeflow-userid",

--- a/src/charm.py
+++ b/src/charm.py
@@ -164,7 +164,7 @@ class KubeflowDashboardOperator(CharmBase):
                     "command": self._service,
                     "startup": "enabled",
                     "environment": {
-                        "NODE_ENV": "production":,
+                        "NODE_ENV": "production",
                         "USERID_HEADER": "kubeflow-userid",
                         "USERID_PREFIX": "",
                         "PROFILES_KFAM_SERVICE_HOST": f"{self.profiles_service}.{self.model.name}",

--- a/src/charm.py
+++ b/src/charm.py
@@ -167,6 +167,7 @@ class KubeflowDashboardOperator(CharmBase):
                     "summary": "entrypoint of the kubeflow_dashboard_operator image",
                     "command": self._pebble_service_command,
                     "startup": "enabled",
+                    "working-dir": "/app"
                     "environment": {
                         "NODE_ENV": "production",
                         "USERID_HEADER": "kubeflow-userid",

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,7 +61,7 @@ class KubeflowDashboardOperator(CharmBase):
         self._lightkube_field_manager = "lightkube"
         self._profiles_service = None
         self._name = self.model.app.name
-        self._service = "npm start"
+        self._service = "/usr/bin/npm start --prefix /app"
         self._container_name = "kubeflow-dashboard"
         self._container = self.unit.get_container(self._name)
         self._configmap_name = self.model.config["dashboard-configmap"]
@@ -158,12 +158,13 @@ class KubeflowDashboardOperator(CharmBase):
             "summary": "kubeflow-dashboard-operator layer",
             "description": "pebble config layer for kubeflow_dashboard_operator",
             "services": {
-                self._container_name: {
+                "serve": {
                     "override": "replace",
                     "summary": "entrypoint of the kubeflow_dashboard_operator image",
                     "command": self._service,
                     "startup": "enabled",
                     "environment": {
+                        "NODE_ENV": "production":,
                         "USERID_HEADER": "kubeflow-userid",
                         "USERID_PREFIX": "",
                         "PROFILES_KFAM_SERVICE_HOST": f"{self.profiles_service}.{self.model.name}",


### PR DESCRIPTION
Use the CKF owned image for the charm instead of upstream's.

Fixes #164