### PR TITLE
tests: refactor build and deploy test case

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run test
         run: |
-          juju add-model kubeflow --config automatically-retry-hooks=false
+          juju add-model kubeflow
           sg snap_microk8s -c "tox -e integration -- --model kubeflow"
 
       - name: Get juju status

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Run test
         run: |
-          juju add-model kubeflow
+          juju add-model kubeflow --config automatically-retry-hooks=false
           sg snap_microk8s -c "tox -e integration -- --model kubeflow"
 
       - name: Get juju status

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -76,7 +76,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await deploy_and_assert_grafana_agent(
         ops_test.model, CHARM_NAME, metrics=False, dashboard=False, logging=True
     )
-    
+
     # Wait for everything to be active and idle
     await ops_test.model.wait_for_idle(
         [PROFILES_CHARM_NAME, CHARM_NAME],

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -68,6 +68,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
     # Wait for everything to be active and idle
     await ops_test.model.wait_for_idle(
         [PROFILES_CHARM_NAME, CHARM_NAME],
+        status="active",
         raise_on_error=True,
         timeout=600,
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -60,27 +60,14 @@ async def test_build_and_deploy(ops_test: OpsTest):
     image_path = METADATA["resources"]["oci-image"]["upstream-source"]
 
     await ops_test.model.deploy(my_charm, resources={"oci-image": image_path}, trust=True)
-
-    await ops_test.model.wait_for_idle(
-        [CHARM_NAME],
-        raise_on_error=True,
-        timeout=300,
-    )
-    assert ops_test.model.applications[CHARM_NAME].units[0].workload_status == "blocked"
-    assert (
-        ops_test.model.applications[CHARM_NAME].units[0].workload_status_message
-        == "Add required relation to kubeflow-profiles"
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.abort_on_fail
-async def test_add_profile_relation(ops_test: OpsTest):
     await ops_test.model.deploy(PROFILES_CHARM_NAME, channel="latest/edge", trust=True)
+
+    # Add relation between kubeflow-dashboard-operator and kubeflow-profile-operator
     await ops_test.model.relate(PROFILES_CHARM_NAME, CHARM_NAME)
+
+    # Wait for everything to be active and idle
     await ops_test.model.wait_for_idle(
         [PROFILES_CHARM_NAME, CHARM_NAME],
-        status="active",
         raise_on_error=True,
         timeout=600,
     )


### PR DESCRIPTION
Remove the assertion that tests the kubeflow-dashboard-operator goes to Blocked when the relation with kubeflow-profiles is not there. This assertion is already covered in unit tests, and it is only adding noise at deployment time.

~~This commit ensures the dependencies like charms and relations are deployed on time which will give time for everything to be set up before moving ahead with other test cases.~~