### PR TITLE
Revert "chore: use charmedkubeflow/kubeflow-central-dashboard as oci-image (#178)"

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,7 +12,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: charmedkubeflow/kubeflow-central-dashboard:1.8-0719441
+    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.8.0
 provides:
   links:
     interface: kubeflow_dashboard_links

--- a/src/charm.py
+++ b/src/charm.py
@@ -61,11 +61,7 @@ class KubeflowDashboardOperator(CharmBase):
         self._lightkube_field_manager = "lightkube"
         self._profiles_service = None
         self._name = self.model.app.name
-
-        # The service name must be consistent with the one defined in the rockcraft project
-        self._pebble_service_name = "serve"
-        self._pebble_service_command = "/usr/bin/npm start"
-
+        self._service = "npm start"
         self._container_name = "kubeflow-dashboard"
         self._container = self.unit.get_container(self._name)
         self._configmap_name = self.model.config["dashboard-configmap"]
@@ -162,14 +158,12 @@ class KubeflowDashboardOperator(CharmBase):
             "summary": "kubeflow-dashboard-operator layer",
             "description": "pebble config layer for kubeflow_dashboard_operator",
             "services": {
-                self._pebble_service_name: {
+                self._container_name: {
                     "override": "replace",
                     "summary": "entrypoint of the kubeflow_dashboard_operator image",
-                    "command": self._pebble_service_command,
+                    "command": self._service,
                     "startup": "enabled",
-                    "working-dir": "/app",
                     "environment": {
-                        "NODE_ENV": "production",
                         "USERID_HEADER": "kubeflow-userid",
                         "USERID_PREFIX": "",
                         "PROFILES_KFAM_SERVICE_HOST": f"{self.profiles_service}.{self.model.name}",


### PR DESCRIPTION
This reverts commit 2ad140e8119e0c594e3e311ef9e7a3446645d0f0.

This is a temporal workaround to help avoid #188. This change must be reverted again once the fix for it is available. Please note the fix depends on a newer version of juju.