### PR TITLE
Update links and image for 1.9.0

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -40,7 +40,7 @@ options:
     description: Whether to enable the registration flow on sign-in
   menu-link-order:
     type: string
-    default: '["Notebooks", "Experiments (AutoML)", "Experiments (KFP)", "Pipelines", "Runs", "Recurring Runs", "Volumes", "Tensorboards"]'
+    default: '["Notebooks", "Katib Experiments", "Experiments (KFP)", "Pipelines", "Runs", "Recurring Runs", "Volumes", "TensorBoards"]'
     description: >
       YAML or JSON formatted list of strings defining the order of the menu links in the dashboard sidebar.  
       For usage details, see https://github.com/canonical/kubeflow-dashboard-operator.
@@ -52,7 +52,7 @@ options:
       For usage details, see https://github.com/canonical/kubeflow-dashboard-operator.
   quick-link-order:
     type: string
-    default: '["Upload a pipeline","View all pipeline runs","Create a new Notebook server","View Katib Experiments"]'
+    default: '["Create a new Notebook server", "Upload a Pipeline", "View Pipeline Runs"]'
     description: >
       YAML or JSON formatted list of strings defining the order of the quick links in the dashboard sidebar.  
       For usage details, see https://github.com/canonical/kubeflow-dashboard-operator.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,7 +12,7 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.8.0
+    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.9.0-rc.0
 provides:
   links:
     interface: kubeflow_dashboard_links

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -12,7 +12,8 @@ resources:
     type: oci-image
     description: 'Backing OCI image'
     auto-fetch: true
-    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.9.0-rc.0
+    # On using the ROCK, modify the service command in the charm.py to remove tini
+    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.9.0-rc.1
 provides:
   links:
     interface: kubeflow_dashboard_links

--- a/src/charm.py
+++ b/src/charm.py
@@ -63,6 +63,9 @@ class KubeflowDashboardOperator(CharmBase):
         self._lightkube_field_manager = "lightkube"
         self._profiles_service = None
         self._name = self.model.app.name
+        # Remove tini when using the rock
+        # Uncomment when using the rock and remove the line below
+        # self._service = "npm start"
         self._service = "/sbin/tini -- npm start"
         self._container_name = "kubeflow-dashboard"
         self._container = self.unit.get_container(self._name)

--- a/src/charm.py
+++ b/src/charm.py
@@ -63,7 +63,7 @@ class KubeflowDashboardOperator(CharmBase):
         self._lightkube_field_manager = "lightkube"
         self._profiles_service = None
         self._name = self.model.app.name
-        self._service = "npm start"
+        self._service = "/sbin/tini -- npm start"
         self._container_name = "kubeflow-dashboard"
         self._container = self.unit.get_container(self._name)
         self._configmap_name = self.model.config["dashboard-configmap"]


### PR DESCRIPTION
Related to: https://github.com/canonical/kubeflow-dashboard-operator/issues/190

Compared tags `v1.8.0` and `v1.9.0-rc.0` for files `https://github.com/kubeflow/kubeflow/tree/master/components/centraldashboard/manifests/overlays/kserve`

[Some of the links in the configmap ](https://github.com/kubeflow/kubeflow/blob/master/components/centraldashboard/manifests/base/configmap.yaml#L7)changed upstream. This PR resolves the changes related to this charm.

Changes:
- changing the order of some quick links related to upstream change