### PR TITLE
Order dashboard menu links

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -40,7 +40,7 @@ options:
     description: Whether to enable the registration flow on sign-in
   menu-link-order:
     type: string
-    default: '["Notebooks", "Katib Experiments", "Experiments (KFP)", "Pipelines", "Runs", "Recurring Runs", "Volumes", "TensorBoards"]'
+    default: '["Notebooks", "TensorBoards", "Volumes", "Katib Experiments", "Pipelines", "Experiments (KFP)", "Runs", "Recurring Runs", "Artifacts", "Executions"]'
     description: >
       YAML or JSON formatted list of strings defining the order of the menu links in the dashboard sidebar.  
       For usage details, see https://github.com/canonical/kubeflow-dashboard-operator.


### PR DESCRIPTION
Closes: https://github.com/canonical/kubeflow-dashboard-operator/issues/214
Ordered links according to upstream ordering (except the nesting feature). 

I have tested the setting with latest/beta.

Screenshot of final ordering: 
![image](https://github.com/user-attachments/assets/e177cac6-d7b8-41c6-9dcc-a23f077f7b44)

Upstream ordering: 
![image](https://github.com/user-attachments/assets/3e00311a-432a-4ae6-89eb-4a7f9ffa597b)

Please first merge this PR to fix blocking issue: https://github.com/canonical/kubeflow-dashboard-operator/pull/218