### PR TITLE
Fix Rust compiler

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -12,3 +12,4 @@ bases:
 parts:
   charm:
     charm-python-packages: [setuptools, pip]
+    build-packages: [cargo, rustc, pkg-config, libffi-dev, libssl-dev]


### PR DESCRIPTION
Closes: https://github.com/canonical/kubeflow-dashboard-operator/issues/217

Added build-packages to fix the build process.