### PR TITLE
fix: observe `upgrade_charm` event in `KubeflowDashboardLinksRequirer`

### DIFF
--- a/lib/charms/kubeflow_dashboard/v0/kubeflow_dashboard_links.py
+++ b/lib/charms/kubeflow_dashboard/v0/kubeflow_dashboard_links.py
@@ -75,7 +75,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 
 DASHBOARD_LINK_LOCATIONS = ['menu', 'external', 'quick', 'documentation']
@@ -291,6 +291,8 @@ class KubeflowDashboardLinksRequirer(Object):
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created, self._on_send_data
         )
+
+        self.framework.observe(self._charm.on.upgrade_charm, self._on_send_data)
 
         # apply user defined events
         if refresh_event:

--- a/tests/unit/test_sidebar_lib.py
+++ b/tests/unit/test_sidebar_lib.py
@@ -336,6 +336,32 @@ class TestRequirer:
 
         assert actual_sidebar_items == REQUIRER_DASHBOARD_LINKS
 
+    def test_send_dashboard_links_on_upgrade_charm(self):
+        """Test that the Requirer correctly handles the upgrade charm event."""
+        # Arrange
+        other_app = "provider"
+        harness = Harness(DummyRequirerCharm, meta=DUMMY_REQUIRER_METADATA)
+        harness.set_leader(True)
+        harness.begin()
+
+        # Act
+
+        # Disable hooks to prevent relation_created handler from updating the relation data
+        harness.disable_hooks()
+
+        relation_id = harness.add_relation(relation_name=RELATION_NAME, remote_app=other_app)
+
+        harness.enable_hooks()
+
+        harness.charm.on.upgrade_charm.emit()
+
+        # Assert
+        actual_sidebar_items = get_sidebar_items_from_relation(
+            harness, relation_id, harness.model.app
+        )
+
+        assert actual_sidebar_items == REQUIRER_DASHBOARD_LINKS
+
     def test_send_dashboard_links_without_leadership(self):
         """Tests whether library incorrectly sends sidebar data when unit is not leader."""
         # Arrange


### PR DESCRIPTION
part of fixing #213 

## Summary
Modifies the `KubeflowDashboardLinks` Library to have the requirer observe the `upgrade_charm` event so that the relation data gets updated in the event of charm upgrade

## Testing
Note: the library patch is not published yet, I will publish it once the PR is approved and before merging it.

1. deploy CKF 1.8/stable
2. pick one of the charms on the requirer side of `dashboard-links` relation for which we know the links have change from 1.8 to 1.9 for example `kfp-ui`
3. clone the repo of `kfp-ui` charm (stay on `main` branch) and edit the `kubeflow_dashboard_links.py` under `lib/charms` to have the changes done in this PR.
4. pack the `kfp-ui` charm
5. refresh the deployed charm to the packed one with `juju refresh`
6. access the dashboard to check the new links are there OR view the relation data with:
```
juju show-unit kubeflow-dashboard/0 --related-unit=kfp-ui/0
```