### PR TITLE
chore: update images for kf 1.9.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,7 +13,7 @@ resources:
     description: 'Backing OCI image'
     auto-fetch: true
     # On using the ROCK, modify the service command in the charm.py to remove tini
-    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.9.0-rc.1
+    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.9.0
 provides:
   links:
     interface: kubeflow_dashboard_links


### PR DESCRIPTION
Closes: https://github.com/canonical/kubeflow-dashboard-operator/issues/215

I have compared tags `v1.9.0` and `v1.9.0-rc.1` for this files https://github.com/kubeflow/manifests/tree/v1.9.0?tab=readme-ov-file#central-dashboard