### PR TITLE
Change override to 'merge' to correctly propagate values from the centraldashboard rock

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -166,11 +166,10 @@ class KubeflowDashboardOperator(CharmBase):
             "description": "pebble config layer for kubeflow_dashboard_operator",
             "services": {
                 self._container_name: {
-                    "override": "replace",
+                    "override": "merge",
                     "summary": "entrypoint of the kubeflow_dashboard_operator image",
                     "command": self._service,
                     "startup": "enabled",
-                    "working-dir": "/usr/src/app",
                     "environment": {
                         "USERID_HEADER": "kubeflow-userid",
                         "USERID_PREFIX": "",

--- a/src/charm.py
+++ b/src/charm.py
@@ -170,6 +170,7 @@ class KubeflowDashboardOperator(CharmBase):
                     "summary": "entrypoint of the kubeflow_dashboard_operator image",
                     "command": self._service,
                     "startup": "enabled",
+                    "working_dir": "/usr/src/app",
                     "environment": {
                         "USERID_HEADER": "kubeflow-userid",
                         "USERID_PREFIX": "",

--- a/src/charm.py
+++ b/src/charm.py
@@ -181,7 +181,7 @@ class KubeflowDashboardOperator(CharmBase):
                         "DASHBOARD_CONFIGMAP": self._configmap_name,
                         "LOGOUT_URL": "/authservice/logout",
                         "POD_NAMESPACE": self.model.name,  # Added due to https://github.com/canonical/bundle-kubeflow/issues/698  # noqa E501
-                        "NODE_ENV": "production"
+                        "NODE_ENV": "production",
                     },
                 }
             },

--- a/src/charm.py
+++ b/src/charm.py
@@ -170,7 +170,7 @@ class KubeflowDashboardOperator(CharmBase):
                     "summary": "entrypoint of the kubeflow_dashboard_operator image",
                     "command": self._service,
                     "startup": "enabled",
-                    "working_dir": "/usr/src/app",
+                    "working-dir": "/usr/src/app",
                     "environment": {
                         "USERID_HEADER": "kubeflow-userid",
                         "USERID_PREFIX": "",
@@ -181,6 +181,7 @@ class KubeflowDashboardOperator(CharmBase):
                         "DASHBOARD_CONFIGMAP": self._configmap_name,
                         "LOGOUT_URL": "/authservice/logout",
                         "POD_NAMESPACE": self.model.name,  # Added due to https://github.com/canonical/bundle-kubeflow/issues/698  # noqa E501
+                        "NODE_ENV": "production"
                     },
                 }
             },

--- a/src/charm.py
+++ b/src/charm.py
@@ -180,7 +180,6 @@ class KubeflowDashboardOperator(CharmBase):
                         "DASHBOARD_CONFIGMAP": self._configmap_name,
                         "LOGOUT_URL": "/authservice/logout",
                         "POD_NAMESPACE": self.model.name,  # Added due to https://github.com/canonical/bundle-kubeflow/issues/698  # noqa E501
-                        "NODE_ENV": "production",
                     },
                 }
             },


### PR DESCRIPTION
Closes [issue 104 on the kubeflow-rocks repo](https://github.com/canonical/kubeflow-rocks/issues/104) along with [this PR](https://github.com/canonical/kubeflow-rocks/pull/120).

This PR changes the override strategy from `replace` to `merge`. This way, we do not need to set the `working-dir` value that is needed when integrating with the `centraldashboard` rock.