### PR TITLE
Backport: Change override to 'merge' to correctly propagate values from the centraldashboard rock

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -161,7 +161,7 @@ class KubeflowDashboardOperator(CharmBase):
             "description": "pebble config layer for kubeflow_dashboard_operator",
             "services": {
                 self._container_name: {
-                    "override": "replace",
+                    "override": "merge",
                     "summary": "entrypoint of the kubeflow_dashboard_operator image",
                     "command": self._service,
                     "startup": "enabled",


### PR DESCRIPTION
This PR is a backport of #221, and along with [this PR](https://github.com/canonical/kubeflow-rocks/pull/121) fix [this issue](https://github.com/canonical/kubeflow-rocks/issues/104) on the kubeflow-rocks repo.