### PR TITLE
backport: Bump jinja2 3.1.x -> 3.1.4

### DIFF
--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -42,7 +42,7 @@ importlib-resources==6.0.1
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.2
+jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ idna==3.4
     #   requests
 importlib-resources==6.0.1
     # via jsonschema
-jinja2==3.1.2
+jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface


### PR DESCRIPTION
This PR is a backport that fixes [this issue](https://github.com/canonical/bundle-kubeflow/issues/883).

It bumps the version of `jinja2` that is specified in the `requirements.txt` file.