### PR TITLE
Add terraform module

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -28,6 +28,14 @@ jobs:
 
     - name: Lint code
       run: tox -e lint
+  
+  terraform-checks:
+    name: Terraform
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/terraform-checks.yaml@main
+    with:
+      charm-path: .
+      model: kubeflow
+      channel: latest/edge
 
   unit:
     name: Unit Test

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ geckodriver.log
 venv
 # vscode 
 .vscode
+.terraform*
+*.tfstate*

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,63 @@
+# Terraform module for kubeflow-dashboard
+
+This is a Terraform module facilitating the deployment of the kubeflow-dashboard charm, using the [Terraform juju provider](https://github.com/juju/terraform-provider-juju/). For more information, refer to the provider [documentation](https://registry.terraform.io/providers/juju/juju/latest/docs). 
+
+## Compatibility
+This terraform module is compatible with charms of version >= 1.8 due to changes in the charm's relations.
+
+## Requirements
+This module requires a `juju` model to be available. Refer to the [usage section](#usage) below for more details.
+
+## API
+
+### Inputs
+The module offers the following configurable inputs:
+
+| Name | Type | Description | Required |
+| - | - | - | - |
+| `app_name`| string | Application name | False |
+| `channel`| string | Channel that the charm is deployed from | False |
+| `config`| map(string) | Map of the charm configuration options | False |
+| `model_name`| string | Name of the model that the charm is deployed on | True |
+| `resources`| map(string) | Map of the charm resources | False |
+| `revision`| number | Revision number of the charm name | False |
+
+### Outputs
+Upon applied, the module exports the following outputs:
+
+| Name | Description |
+| - | - |
+| `app_name`|  Application name |
+| `provides`| Map of `provides` endpoints |
+| `requires`|  Map of `reqruires` endpoints |
+
+## Usage
+
+This module is intended to be used as part of a higher-level module. When defining one, users should ensure that Terraform is aware of the `juju_model` dependency of the charm module. There are two options to do so when creating a high-level module:
+
+### Define a `juju_model` resource
+Define a `juju_model` resource and pass to the `model_name` input a reference to the `juju_model` resource's name. For example:
+
+```
+resource "juju_model" "testing" {
+  name = kubeflow
+}
+
+module "kubeflow-dashboard" {
+  source = "<path-to-this-directory>"
+  model_name = juju_model.testing.name
+}
+```
+
+### Define a `data` source
+Define a `data` source and pass to the `model_name` input a reference to the `data.juju_model` resource's name. This will enable Terraform to look for a `juju_model` resource with a name attribute equal to the one provided, and apply only if this is present. Otherwise, it will fail before applying anything.
+```
+data "juju_model" "testing" {
+  name = var.model_name
+}
+
+module "kubeflow-dashboard" {
+  source = "<path-to-this-directory>"
+  model_name = data.juju_model.testing.name
+}
+```

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,13 @@
+resource "juju_application" "kubeflow_dashboard" {
+  charm {
+    name     = "kubeflow-dashboard"
+    channel  = var.channel
+    revision = var.revision
+  }
+  config    = var.config
+  model     = var.model_name
+  name      = var.app_name
+  resources = var.resources
+  trust     = true
+  units     = 1
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,18 @@
+output "app_name" {
+  value = juju_application.kubeflow_dashboard.name
+}
+
+output "provides" {
+  value = {
+    links = "links",
+    grafana_dashboard = "grafana-dashboard"
+  }
+}
+
+output "requires" {
+  value = {
+    ingress = "ingress",
+    kubeflow_profiles = "kubeflow-profiles",
+    logging = "logging"
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,34 @@
+variable "app_name" {
+  description = "Application name"
+  type        = string
+  default     = "kubeflow-dashboard"
+}
+
+variable "channel" {
+  description = "Charm channel"
+  type        = string
+  default     = null
+}
+
+variable "config" {
+  description = "Map of charm configuration options"
+  type        = map(string)
+  default     = {}
+}
+
+variable "model_name" {
+  description = "Model name"
+  type        = string
+}
+
+variable "resources" {
+  description = "Map of resources"
+  type        = map(string)
+  default     = null
+}
+
+variable "revision" {
+  description = "Charm revision"
+  type        = number
+  default     = null
+}

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.6"
+  required_providers {
+    juju = {
+      source  = "juju/juju"
+      version = "~> 0.14.0"
+    }
+  }
+}

--- a/tox.ini
+++ b/tox.ini
@@ -64,6 +64,13 @@ deps =
     -r requirements-lint.txt
 description = Check code against coding style standards
 
+[testenv:tflint]
+allowlist_externals =
+    tflint
+commands =
+    tflint --chdir=terraform --recursive
+description = Check Terraform code against coding style standards
+
 [testenv:unit]
 commands =
     coverage run --source={[vars]src_path} \


### PR DESCRIPTION
Create a `terraform/` directory that hosts the Terraform module for this charm. It follows the structure proposed in [this spec](https://docs.google.com/document/d/1EG71A2pJ244PQRaGVzGj7Mx2B_bzE4U_OSqx4eeVI1E/edit) and it is follows what was done in canonical/argo-operators#198.

To test the module:
- Clone the repository and switch this PR's branch.
- First run `tox -e tflint` to ensure that linting is correct
- Run `terraform apply -var "channel=latest/edge" -var "model_name=kubeflow" --auto-approve` and wait until the charm is `Active` and `Idle`.

Closes https://github.com/canonical/kubeflow-dashboard-operator/issues/234