### PR TITLE
chore: update centraldashboard 1.9.0 -> 1.10.0-rc.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,7 +13,7 @@ resources:
     description: 'Backing OCI image'
     auto-fetch: true
     # On using the ROCK, modify the service command in the charm.py to remove tini
-    upstream-source: charmedkubeflow/centraldashboard:1.9.0-385a9c5
+    upstream-source: docker.io/kubeflownotebookswg/centraldashboard:v1.10.0-rc.0
 provides:
   links:
     interface: kubeflow_dashboard_links

--- a/src/charm.py
+++ b/src/charm.py
@@ -180,7 +180,6 @@ class KubeflowDashboardOperator(CharmBase):
                         "DASHBOARD_CONFIGMAP": self._configmap_name,
                         "LOGOUT_URL": "/authservice/logout",
                         "POD_NAMESPACE": self.model.name,  # Added due to https://github.com/canonical/bundle-kubeflow/issues/698  # noqa E501
-                        "COLLECT_METRICS": "true",
                     },
                 }
             },

--- a/src/charm.py
+++ b/src/charm.py
@@ -65,8 +65,8 @@ class KubeflowDashboardOperator(CharmBase):
         self._name = self.model.app.name
         # Uncomment the line below when using the rock and comment the next one
         # and vice versa when using the upstream image
-        self._service = "npm start"
-        # self._service = "/sbin/tini -- npm start"
+        # self._service = "npm start"
+        self._service = "/sbin/tini -- npm start"
         self._container_name = "kubeflow-dashboard"
         self._container = self.unit.get_container(self._name)
         self._configmap_name = self.model.config["dashboard-configmap"]
@@ -180,6 +180,7 @@ class KubeflowDashboardOperator(CharmBase):
                         "DASHBOARD_CONFIGMAP": self._configmap_name,
                         "LOGOUT_URL": "/authservice/logout",
                         "POD_NAMESPACE": self.model.name,  # Added due to https://github.com/canonical/bundle-kubeflow/issues/698  # noqa E501
+                        "COLLECT_METRICS": "true",
                     },
                 }
             },


### PR DESCRIPTION
This commit changes the oci-image from the team's maintained rock to upstream's latest centraldashboard container image (v1.10.0-rc.0). It also changes the workload service to use tini as per indicated in the code comments.

These changes are based on the latest sync of the `kubeflow/kubeflow` to the `kubeflow/manifests` repository. See https://github.com/kubeflow/manifests/pull/2995 for reference.