### PR TITLE
chore: update rock and manifests to 1.10.0 version

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,7 +13,7 @@ resources:
     description: 'Backing OCI image'
     auto-fetch: true
     # On using the ROCK, modify the service command in the charm.py to remove tini
-    upstream-source: docker.io/charmedkubeflow/centraldashboard:1.10.0-rc.1-a69c851
+    upstream-source: docker.io/charmedkubeflow/centraldashboard:1.10.0-8dd1032
 provides:
   links:
     interface: kubeflow_dashboard_links


### PR DESCRIPTION
Based on the upstream 1.10 updates [PR](https://github.com/kubeflow/kubeflow/commit/90e987bf87d3e7c900926310b00bfa16b59e41eb) and manifests update [PR](https://github.com/kubeflow/manifests/pull/3071). There have been no updates to the manifests in dashboard. This PR bumps the rock to v1.10.0.

Closes https://warthogs.atlassian.net/browse/KF-7146