### PR TITLE
fix: include metrics-endpoint in Terraform module outputs (#273)

### DIFF
--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -5,7 +5,8 @@ output "app_name" {
 output "provides" {
   value = {
     links             = "links",
-    grafana_dashboard = "grafana-dashboard"
+    grafana_dashboard = "grafana-dashboard",
+    metrics_endpoint  = "metrics-endpoint"
   }
 }
 


### PR DESCRIPTION
Include `metrics-endpoint` in the Terraform module's output Fix #272