### PR TITLE
chore: Update CI to use Canonical K8s

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -55,14 +55,15 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-            provider: microk8s
-            channel: 1.32-strict/stable
-            microk8s-addons: "dns hostpath-storage rbac ingress metallb:10.64.140.43-10.64.140.49"
-            juju-channel: 3.6/stable
-            charmcraft-channel: 3.x/stable
+      - name: Install dependencies
+        run: pipx install tox
+
+      - name: Setup environment
+        run: |
+          sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
+          sudo rm -rf /run/containerd
+          sudo snap install concierge --classic
+          sudo concierge prepare --trace
 
       - name: Install Chrome driver
         run: |

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -20,6 +20,7 @@ providers:
   lxd:
     enable: true
     bootstrap: false
+    channel: latest/stable
 
 host:
   snaps:

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,0 +1,25 @@
+juju:
+  channel: 3.6/stable
+
+providers:
+  k8s:
+    enable: true
+    bootstrap: true
+    channel: 1.32-classic/stable
+    features:
+      local-storage:
+      load-balancer:
+        enabled: true
+        l2-mode: true
+        cidrs: 10.64.140.43/32
+    bootstrap-constraints:
+      root-disk: 4G
+
+  lxd:
+    enable: true
+    bootstrap: false
+
+host:
+  snaps:
+    charmcraft:
+      channel: 3.x/stable

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,5 +1,7 @@
 juju:
   channel: 3.6/stable
+  model-defaults:
+    logging-config: <root>=INFO; unit=DEBUG
 
 providers:
   k8s:
@@ -13,7 +15,7 @@ providers:
         l2-mode: true
         cidrs: 10.64.140.43/32
     bootstrap-constraints:
-      root-disk: 4G
+      root-disk: 2G
 
   lxd:
     enable: true


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1334

This PR:
- Updates the CI to use [Canonical Kubernetes](https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/) instead of microk8s.
- Includes a `concierge.yaml` in the root directory for easily deploying a Canonical K8s cluster using `concierge`.
