### PR TITLE
chore: integrate rock image centraldashboard:1.10.0-e346d61 (#290)

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,7 +13,7 @@ resources:
     description: 'Backing OCI image'
     auto-fetch: true
     # On using the ROCK, modify the service command in the charm.py to remove tini
-    upstream-source: docker.io/charmedkubeflow/centraldashboard:1.10.0-8dd1032
+    upstream-source: docker.io/charmedkubeflow/centraldashboard:1.10.0-e346d61
 provides:
   links:
     interface: kubeflow_dashboard_links


### PR DESCRIPTION
canonical/kubeflow-rocks#247 for canonical/bundle-kubeflow#1259.