### PR TITLE
terraform: change default base to 24.04

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -13,6 +13,7 @@ The module offers the following configurable inputs:
 | Name | Type | Description | Required |
 | - | - | - | - |
 | `app_name`| string | Application name | False |
+| `base`| string | Application base | False |
 | `channel`| string | Channel that the charm is deployed from | False |
 | `config`| map(string) | Map of the charm configuration options | False |
 | `model_name`| string | Name of the model that the charm is deployed on | True |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,6 +1,7 @@
 resource "juju_application" "kubeflow_dashboard" {
   charm {
     name     = "kubeflow-dashboard"
+    base     = var.base
     channel  = var.channel
     revision = var.revision
   }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -4,6 +4,12 @@ variable "app_name" {
   default     = "kubeflow-dashboard"
 }
 
+variable "base" {
+  description = "Application base"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "channel" {
   description = "Charm channel"
   type        = string


### PR DESCRIPTION
Updates the default base in the terraform module to 24.04 now that the
charm with 24.04 base is released to stable (done in this [action](https://github.com/canonical/kubeflow-dashboard-operator/actions/runs/17320449248)).
This is needed to fix canonical/bundle-kubeflow#1259, so by default, the
charm uses image from canonical/kubeflow-rocks#247.