### PR TITLE
fix(ci): Introduce base-channel input in promote workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ on:
       origin-channel:
         description: 'Origin Channel'
         required: true
+      base-image-channel:
+        description: 'Base Image Channel. Defaults to 24.04'
+        default: '24.04'
+        required: false
 
 jobs:
   promote-charm:
@@ -24,3 +28,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
+          base-channel: ${{ github.event.inputs.base-image-channel }}


### PR DESCRIPTION
Introduce base-channel input in promote workflow. From main, this always run using 20.04 (see [input](https://github.com/canonical/kubeflow-dashboard-operator/actions/runs/17320449248/job/49172342285#step:3:8) and [result](https://github.com/canonical/kubeflow-dashboard-operator/actions/runs/17320449248/job/49172342285#step:3:725)). From this branch, the charm was properly updated for base 24.04 (see [input](https://github.com/canonical/kubeflow-dashboard-operator/actions/runs/17320766258/job/49173375541#step:3:7) and [result](https://github.com/canonical/kubeflow-dashboard-operator/actions/runs/17320766258/job/49173375541#step:3:725)). 