### PR TITLE
(backport): Update CI to use Canonical K8s

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -65,14 +65,15 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Setup operator environment
-        uses: charmed-kubernetes/actions-operator@main
-        with:
-            provider: microk8s
-            channel: 1.32-strict/stable
-            microk8s-addons: "dns hostpath-storage rbac ingress metallb:10.64.140.43-10.64.140.49"
-            juju-channel: 3.6/stable
-            charmcraft-channel: 3.x/stable
+      - name: Install dependencies
+        run: pipx install tox
+
+      - name: Setup environment
+        run: |
+          sudo apt-get remove -y docker-ce docker-ce-cli containerd.io
+          sudo rm -rf /run/containerd
+          sudo snap install concierge --classic
+          sudo concierge prepare --trace
 
       - name: Install Chrome driver
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,10 @@ on:
       origin-channel:
         description: 'Origin Channel'
         required: true
+      base-image-channel:
+        description: 'Base Image Channel. Defaults to 24.04'
+        default: '24.04'
+        required: false
 
 jobs:
   promote-charm:
@@ -24,3 +28,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           destination-channel: ${{ github.event.inputs.destination-channel }}
           origin-channel: ${{ github.event.inputs.origin-channel }}
+          base-channel: ${{ github.event.inputs.base-image-channel }}

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -1,0 +1,28 @@
+juju:
+  channel: 3.6/stable
+  model-defaults:
+    logging-config: <root>=INFO; unit=DEBUG
+
+providers:
+  k8s:
+    enable: true
+    bootstrap: true
+    channel: 1.32-classic/stable
+    features:
+      local-storage:
+      load-balancer:
+        enabled: true
+        l2-mode: true
+        cidrs: 10.64.140.43/32
+    bootstrap-constraints:
+      root-disk: 2G
+
+  lxd:
+    enable: true
+    bootstrap: false
+    channel: latest/stable
+
+host:
+  snaps:
+    charmcraft:
+      channel: 3.x/stable


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1334

This PR backports the update to use Canonical K8s in our integration tests. Note that we also backport a fix to use `24.04` as base in the `release-charm` action.