### PR TITLE
fix: Change dump-charm-debug-artifacts on failure

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -91,9 +91,7 @@ jobs:
         if: failure()
 
       - uses: canonical/kubeflow-ci/actions/dump-charm-debug-artifacts@main
-        # always() if you want this to run on every run, regardless of failure.
-        # more details: https://docs.github.com/en/actions/learn-github-actions/expressions#status-check-functions
-        if: always()
+        if: failure()
 
       - name: Upload selenium screenshots
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Ref: https://github.com/canonical/bundle-kubeflow/issues/1341

This PR backports a change to only run the `dump-charm-debug-artifacts` action on failure in order to save time.