### PR TITLE
chore: pin the terraform version to < 1.0.0

### DIFF
--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.14.0"
+      version = ">= 0.14.0, < 1.0.0"
     }
   }
 }


### PR DESCRIPTION
Cherry-picks https://github.com/canonical/kubeflow-dashboard-operator/pull/302