### PR TITLE
feat: migrate to Kubeflow Dashboard V2

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,7 +17,7 @@ resources:
     # If upstream Docker image is integrated replace the command to
     # /sbin/tini -- npm start
     # in the service-config.yaml
-    upstream-source: docker.io/charmedkubeflow/centraldashboard:1.10.0-e346d61
+    upstream-source: docker.io/dariofaccin/centraldashboard:2.0.0-c537efa
 provides:
   links:
     interface: kubeflow_dashboard_links


### PR DESCRIPTION
This PR migrates the Kubeflow Dashboard operator image to version 2.0.0.

This PR uses a custom rock from [this PR](https://github.com/canonical/kubeflow-rocks/pull/272).