### PR TITLE
[DO NOT MERGE] test: fix Dashboard path

### DIFF
--- a/tests/integration/test_charm_ambient.py
+++ b/tests/integration/test_charm_ambient.py
@@ -50,7 +50,7 @@ DEFAULT_DOCUMENTATION_TEXTS = [
 HEADERS = {
     "kubeflow-userid": "test",
 }
-HTTP_PATH = "/volumes/"
+HTTP_PATH = "/some-path-that-does-not-exist/"
 KUBEFLOW_PROFILES_RELATION_NAME = "kubeflow-profiles"
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
This pull request fixes the Dashboard path validated in integration tests.

note: the first commit was just to make sure that paths that do not exist do make tests fail, because the path previously used was to the Volumes web app, and tests were successfully passing despite the Volumes web app not being deployed, probably because the UI page for Volumes was actually there, even if empty, giving a successful yet empty response (without the tests checking for HTML content)