### PR TITLE
chore: pin charm dependencies in tests (track/2.0)

### DIFF
--- a/tests/integration/charms_dependencies.py
+++ b/tests/integration/charms_dependencies.py
@@ -2,4 +2,4 @@
 
 from charmed_kubeflow_chisme.testing import CharmSpec
 
-KUBEFLOW_PROFILES = CharmSpec(charm="kubeflow-profiles", channel="latest/edge", trust=True)
+KUBEFLOW_PROFILES = CharmSpec(charm="kubeflow-profiles", channel="2.0/edge", trust=True)


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### External — entries marked _(override)_ are pinned via `config.FALLBACK_OVERRIDES`
- `kubeflow-profiles`: `latest/edge` → `2.0/edge` _(override)_

Refs: canonical/bundle-kubeflow#1379
