### PR TITLE
fix: handle multiple istio-ingress-route relations

### DIFF
--- a/concierge.yaml
+++ b/concierge.yaml
@@ -13,7 +13,7 @@ providers:
       load-balancer:
         enabled: true
         l2-mode: true
-        cidrs: 10.64.140.43/32
+        cidrs: 10.64.140.42/31  # NOTE: at least two IPs required for integration tests: one for each of the two Istio ingress gateways
     bootstrap-constraints:
       root-disk: 2G
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -3032,6 +3032,13 @@ optional = false
 python-versions = ">=3.8"
 groups = ["charm", "integration", "unit"]
 files = [
+    {file = "PyYAML-6.0.3-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c2514fceb77bc5e7a2f7adfaa1feb2fb311607c9cb518dbc378688ec73d8292f"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c57bb8c96f6d1808c030b1687b9b5fb476abaa47f0db9c0101f5e9f394e97f4"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:efd7b85f94a6f21e4932043973a7ba2613b059c4a000551892ac9f1d11f5baf3"},
+    {file = "PyYAML-6.0.3-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:22ba7cfcad58ef3ecddc7ed1db3409af68d023b7f940da23c6c2a1890976eda6"},
+    {file = "PyYAML-6.0.3-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:6344df0d5755a2c9a276d4473ae6b90647e216ab4757f8426893b5dd2ac3f369"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win32.whl", hash = "sha256:3ff07ec89bae51176c0549bc4c63aa6202991da2d9a6129d7aef7f1407d3f295"},
+    {file = "PyYAML-6.0.3-cp38-cp38-win_amd64.whl", hash = "sha256:5cf4e27da7e3fbed4d6c3d8e797387aaad68102272f8f9752883bc32d61cb87b"},
     {file = "pyyaml-6.0.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:214ed4befebe12df36bcc8bc2b64b396ca31be9304b8f59e25c11cf94a4c033b"},
     {file = "pyyaml-6.0.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:02ea2dfa234451bbb8772601d7b8e426c2bfa197136796224e50e35a78777956"},
     {file = "pyyaml-6.0.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b30236e45cf30d2b8e7b3e85881719e98507abed1011bf463a8fa23e9c3e98a8"},
@@ -3941,4 +3948,4 @@ cffi = ["cffi (>=1.17,<2.0) ; platform_python_implementation != \"PyPy\" and pyt
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "2b6102f3678865371af0dac0c2c1ca1e4a1ee6d7d7bfc7c09e945cd4faeecc84"
+content-hash = "e0c01021c2f506e4b56c8558336ee12f5b033e76975fd681dd0668d56a01e362"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ optional = true
 juju = "<4.0"
 charmed-kubeflow-chisme = ">=0.4.18"
 aiohttp = "^3.10.11"
+tenacity = "^9.0.0"
 lightkube = "^0.15.6"
 ops = "^2.17.1"
 pytest = "^8.3.4"

--- a/src/charm.py
+++ b/src/charm.py
@@ -289,15 +289,26 @@ class KubeflowDashboardOperator(CharmBase):
             ],
         )
 
+        # submit_config publishes this same config to every istio-ingress-route
+        # relation, so all related ingress providers are (re)configured at once.
         if self.unit.is_leader():
             self.ingress.submit_config(config)
 
     def _check_istio_relations(self):
-        """Check that both ambient and sidecar relations are not present simultaneously."""
-        ambient_relation = self.model.get_relation("istio-ingress-route")
-        sidecar_relation = self.model.get_relation("ingress")
+        """Validate the charm's ingress relations are mutually exclusive.
 
-        if ambient_relation and sidecar_relation:
+        The charm supports both ambient ingress (via the 'istio-ingress-route'
+        endpoint) and sidecar ingress (via the 'ingress' endpoint), but the two
+        cannot be used at the same time. Each endpoint may hold any number of relations,
+        so this inspects the full list of relations on each endpoint.
+
+        Raises:
+            CheckFailed: with BlockedStatus if relations exist on both endpoints.
+        """
+        ambient_relations = self.model.relations["istio-ingress-route"]
+        sidecar_relations = self.model.relations["ingress"]
+
+        if ambient_relations and sidecar_relations:
             self.logger.error(
                 "Both 'istio-ingress-route' and 'ingress' relations are present, "
                 "remove one to unblock."

--- a/tests/integration/test_charm_ambient.py
+++ b/tests/integration/test_charm_ambient.py
@@ -8,9 +8,12 @@ from typing import Dict, List
 
 import pytest
 import pytest_asyncio
+import tenacity
 import yaml
 from charmed_kubeflow_chisme.testing import (
     GRAFANA_AGENT_APP,
+    ISTIO_INGRESS_K8S_APP,
+    ISTIO_INGRESS_ROUTE_ENDPOINT,
     assert_grafana_dashboards,
     assert_logging,
     assert_metrics_endpoint,
@@ -26,6 +29,7 @@ from charms.kubeflow_dashboard.v0.kubeflow_dashboard_links import (
 from charms_dependencies import KUBEFLOW_PROFILES
 from dashboard_links_requirer_tester_charm.src.charm import generate_links_for_location
 from lightkube import Client
+from lightkube.generic_resource import create_namespaced_resource
 from lightkube.resources.core_v1 import ConfigMap
 from pytest_operator.plugin import OpsTest
 
@@ -52,6 +56,28 @@ HEADERS = {
 }
 HTTP_PATH = "/volumes/"
 KUBEFLOW_PROFILES_RELATION_NAME = "kubeflow-profiles"
+
+# A second istio-ingress-k8s instance used to verify multiple-ingress support.
+SECOND_INGRESS_APP = "istio-ingress-k8s-alt"
+INGRESS_CHANNEL = "2/stable"
+# Name of the HTTPRoute submitted by kubeflow-dashboard (see charm._ambient_mesh_ingress).
+INGRESS_ROUTE_NAME = "http-ingress"
+# Gateway listener section for cleartext HTTP on port 80.
+HTTP_SECTION_NAME = "http-80"
+# Path matched by the dashboard HTTPRoute.
+INGRESS_ROUTE_PATH = "/"
+# Gateway API generic resources, resolved at runtime via lightkube.
+HTTPROUTE_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "HTTPRoute", "httproutes"
+)
+GATEWAY_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "Gateway", "gateways"
+)
+RETRY_120_SECONDS = tenacity.Retrying(
+    stop=tenacity.stop_after_delay(120),
+    wait=tenacity.wait_fixed(2),
+    reraise=True,
+)
 
 log = logging.getLogger(__name__)
 
@@ -366,8 +392,7 @@ async def assert_links_in_configmap_by_text_value(
     return links_texts
 
 
-@pytest.mark.abort_on_fail
-async def test_ui_is_accessible(ops_test: OpsTest):
+async def assert_ui_is_accessible(ops_test: OpsTest):
     """Verify that UI is accessible through the ingress gateway."""
     await assert_path_reachable_through_ingress(
         http_path=HTTP_PATH,
@@ -376,6 +401,93 @@ async def test_ui_is_accessible(ops_test: OpsTest):
         expected_status=200,
         expected_content_type="text/html",
     )
+
+
+@pytest.mark.abort_on_fail
+async def test_ui_is_accessible(ops_test: OpsTest):
+    """Verify that UI is accessible through the ingress gateway before the second ingress."""
+    await assert_ui_is_accessible(ops_test)
+
+
+@pytest.mark.abort_on_fail
+async def test_deploy_and_relate_second_ingress(ops_test: OpsTest):
+    """Deploy a second istio-ingress-k8s and relate it to kubeflow-dashboard.
+
+    kubeflow-dashboard must accept more than one istio-ingress-route relation without
+    erroring, so it should remain active after the second ingress is related.
+    """
+    await ops_test.model.deploy(
+        ISTIO_INGRESS_K8S_APP,
+        application_name=SECOND_INGRESS_APP,
+        channel=INGRESS_CHANNEL,
+        trust=True,
+    )
+    await ops_test.model.wait_for_idle(
+        [SECOND_INGRESS_APP],
+        raise_on_blocked=False,
+        raise_on_error=False,
+        wait_for_active=True,
+        timeout=60 * 15,
+    )
+
+    await ops_test.model.integrate(
+        f"{SECOND_INGRESS_APP}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+        f"{CHARM_NAME}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+    )
+    await ops_test.model.wait_for_idle(
+        [CHARM_NAME, SECOND_INGRESS_APP],
+        status="active",
+        raise_on_blocked=False,
+        raise_on_error=False,
+        timeout=60 * 10,
+        idle_period=30,
+    )
+
+    assert ops_test.model.applications[CHARM_NAME].units[0].workload_status == "active"
+
+
+async def test_httproute_attached_to_second_gateway(ops_test: OpsTest, lightkube_client: Client):
+    """Verify the HTTPRoute for the second ingress is created and bound to its Gateway.
+
+    The istio-ingress-k8s charm names each route
+    ``{source_app}-{route_name}-httproute-{section}-{ingress_app}`` and binds it to a
+    Gateway named after the ingress application via ``parentRefs``. We assert that the
+    route created for the second ingress is attached to the *second* Gateway (not the
+    first) and routes the dashboard path to the dashboard backend.
+    """
+    namespace = ops_test.model_name
+
+    expected_route_name = (
+        f"{CHARM_NAME}-{INGRESS_ROUTE_NAME}-httproute-{HTTP_SECTION_NAME}-{SECOND_INGRESS_APP}"
+    )
+
+    # The second Gateway should exist, named after the second ingress application.
+    lightkube_client.get(GATEWAY_RESOURCE, name=SECOND_INGRESS_APP, namespace=namespace)
+
+    # Retry to give the ingress charm time to reconcile the HTTPRoute resources.
+    httproute = None
+    for attempt in RETRY_120_SECONDS:
+        with attempt:
+            httproute = lightkube_client.get(
+                HTTPROUTE_RESOURCE, name=expected_route_name, namespace=namespace
+            )
+
+    parent_refs = httproute.spec["parentRefs"]
+    assert len(parent_refs) == 1
+    # The route must be attached to the SECOND gateway, not the first.
+    assert parent_refs[0]["name"] == SECOND_INGRESS_APP
+    assert parent_refs[0]["sectionName"] == HTTP_SECTION_NAME
+
+    # And it must route the dashboard path to the dashboard backend.
+    rule = httproute.spec["rules"][0]
+    assert rule["matches"][0]["path"]["value"] == INGRESS_ROUTE_PATH
+    assert rule["backendRefs"][0]["name"] == CHARM_NAME
+
+
+@pytest.mark.abort_on_fail
+async def test_ui_is_accessible_after_second_ingress(ops_test: OpsTest):
+    """Verify that UI is still accessible through the ingress gateway after the second ingress."""
+    await assert_ui_is_accessible(ops_test)
 
 
 async def test_metrics_enpoint(ops_test: OpsTest):

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -9,7 +9,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 from charmed_kubeflow_chisme.exceptions import GenericCharmRuntimeError
-from charms.istio_ingress_k8s.v0.istio_ingress_route import ProtocolType
+from charmed_kubeflow_chisme.testing import ISTIO_INGRESS_K8S_APP, ISTIO_INGRESS_ROUTE_ENDPOINT
+from charms.istio_ingress_k8s.v0.istio_ingress_route import (
+    HTTPPathMatchType,
+    IstioIngressRouteConfig,
+    ProtocolType,
+)
 from charms.kubeflow_dashboard.v0.kubeflow_dashboard_links import (
     DASHBOARD_LINKS_FIELD,
     DashboardLink,
@@ -28,6 +33,10 @@ from charm import (
 
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 CHARM_NAME = METADATA["name"]
+# Ingress relation endpoints and the apps used to exercise them in tests.
+SIDECAR_INGRESS_ENDPOINT = "ingress"
+SIDECAR_INGRESS_APP = "istio-pilot"
+SECOND_ISTIO_INGRESS_K8S_APP = f"{ISTIO_INGRESS_K8S_APP}-2"
 RELATION_DATA = [
     {
         "app": "tensorboards-web-app",
@@ -386,9 +395,9 @@ class TestSidebarLinks:
     ):
         """Test the charm is in BlockedStatus when both sidecar and ambient relations are added."""
         # Arrange
-        harness.add_relation("ingress", "istio-pilot")
+        harness.add_relation(SIDECAR_INGRESS_ENDPOINT, SIDECAR_INGRESS_APP)
 
-        harness.add_relation("istio-ingress-route", "istio-ingress-k8s")
+        harness.add_relation(ISTIO_INGRESS_ROUTE_ENDPOINT, ISTIO_INGRESS_K8S_APP)
 
         harness.set_leader(True)
 
@@ -403,24 +412,60 @@ class TestSidebarLinks:
         )
 
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
+    @patch("charm.KubeflowDashboardOperator.configmap_handler")
     @patch("charm.KubeflowDashboardOperator.k8s_resource_handler")
     def test_multiple_ambient_relations_added(
+        self,
+        k8s_resource_handler: MagicMock,
+        configmap_handler: MagicMock,
+        harness_with_profiles: Harness,
+    ):
+        """Test the charm reconciles to active with more than one istio-ingress-route relation."""
+        # Arrange
+        harness = harness_with_profiles
+        harness.add_relation(ISTIO_INGRESS_ROUTE_ENDPOINT, ISTIO_INGRESS_K8S_APP)
+        harness.add_relation(ISTIO_INGRESS_ROUTE_ENDPOINT, SECOND_ISTIO_INGRESS_K8S_APP)
+
+        # Act
+        harness.begin_with_initial_hooks()
+        harness.container_pebble_ready(harness.charm._container_name)
+
+        # Assert
+        # More than one relation on the istio-ingress-route endpoint must not block
+        # the charm; it should reconcile all the way to active.
+        assert isinstance(harness.charm.model.unit.status, ActiveStatus)
+
+    @patch("charm.KubernetesServicePatch", lambda x, y: None)
+    @patch("charm.KubeflowDashboardOperator.k8s_resource_handler")
+    def test_each_istio_ingress_route_relation_receives_config(
         self, k8s_resource_handler: MagicMock, harness: Harness
     ):
-        """Test that multiple istio-ingress-route relations are handled without erroring."""
+        """Test that an HTTPRoute config is submitted to every istio-ingress-route relation."""
         # Arrange
-        harness.add_relation("istio-ingress-route", "istio-ingress-k8s")
-        harness.add_relation("istio-ingress-route", "istio-ingress-k8s-2")
+        harness.set_leader(True)
+        rel_id_1 = harness.add_relation(ISTIO_INGRESS_ROUTE_ENDPOINT, ISTIO_INGRESS_K8S_APP)
+        rel_id_2 = harness.add_relation(ISTIO_INGRESS_ROUTE_ENDPOINT, SECOND_ISTIO_INGRESS_K8S_APP)
 
         # Act
         harness.begin()
 
-        # Inspecting the full list of relations per endpoint must not raise even
-        # though there is more than one relation on a single endpoint.
-        harness.charm._check_istio_relations()
-
         # Assert
-        assert not isinstance(harness.charm.model.unit.status, BlockedStatus)
+        # Each relation's application databag should contain a valid config that
+        # defines the kubeflow-dashboard HTTPRoute, proving the lib handles every ingress.
+        for rel_id in (rel_id_1, rel_id_2):
+            app_data = harness.get_relation_data(rel_id, harness.charm.app.name)
+            assert "config" in app_data
+
+            config = IstioIngressRouteConfig.model_validate_json(app_data["config"])
+            assert len(config.http_routes) == 1
+            http_route = config.http_routes[0]
+            assert http_route.matches[0].path.type == HTTPPathMatchType.PathPrefix
+            assert http_route.matches[0].path.value == "/"
+            assert http_route.backends[0].service == harness.charm.app.name
+            assert http_route.backends[0].port == harness.charm._port
+            # The route's parent (the Gateway listener referenced under parentRefs in
+            # the HTTPRouteSpec) should be the expected HTTP listener.
+            assert http_route.listener.name == "http-80"
 
     @pytest.mark.parametrize("tls_enabled, expected_port", [(False, 80), (True, 443)])
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
@@ -439,7 +484,7 @@ class TestSidebarLinks:
         mock_ingress.tls_enabled = tls_enabled
         mock_ingress_cls.return_value = mock_ingress
 
-        harness.add_relation("istio-ingress-route", "istio-ingress-k8s")
+        harness.add_relation(ISTIO_INGRESS_ROUTE_ENDPOINT, ISTIO_INGRESS_K8S_APP)
         harness.set_leader(True)
         harness.begin()
 

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -402,6 +402,26 @@ class TestSidebarLinks:
             BlockedStatus,
         )
 
+    @patch("charm.KubernetesServicePatch", lambda x, y: None)
+    @patch("charm.KubeflowDashboardOperator.k8s_resource_handler")
+    def test_multiple_ambient_relations_added(
+        self, k8s_resource_handler: MagicMock, harness: Harness
+    ):
+        """Test that multiple istio-ingress-route relations are handled without erroring."""
+        # Arrange
+        harness.add_relation("istio-ingress-route", "istio-ingress-k8s")
+        harness.add_relation("istio-ingress-route", "istio-ingress-k8s-2")
+
+        # Act
+        harness.begin()
+
+        # Inspecting the full list of relations per endpoint must not raise even
+        # though there is more than one relation on a single endpoint.
+        harness.charm._check_istio_relations()
+
+        # Assert
+        assert not isinstance(harness.charm.model.unit.status, BlockedStatus)
+
     @pytest.mark.parametrize("tls_enabled, expected_port", [(False, 80), (True, 443)])
     @patch("charm.KubernetesServicePatch", lambda x, y: None)
     @patch("charm.IstioIngressRouteRequirer")


### PR DESCRIPTION
Part of https://github.com/canonical/bundle-kubeflow/issues/1446

Use `model.relations[...]` instead of `model.get_relation(...)` when checking ingress relations, so the charm no longer raises `TooManyRelatedAppsError` when more than one `istio-ingress-route` relation is present.

Add unit tests covering multiple `istio-ingress-route` relations and verifying each relation receives a valid `HTTPRoute` config.

_Note: this PR was created with the help of AI_